### PR TITLE
Provide coverage information for each build using Coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+branch = True
+erase = True
+source = fireworks, fw_tutorials
+[report]
+exclude_lines =
+    # Ignore coverage of code that requires the module to be executed.
+    if __name__ == .__main__.:
+omit =
+    */python?.?/*
+    */site-packages/*
+    *tests/*
+    */versioneer.py
+    */_version.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,15 @@ python:
   - "3.3"
 install:
   - "pip install -r requirements.txt --use-mirrors"
+  - pip install coverage
+  - pip install python-coveralls
 before_script:
   - python setup.py develop
 script:
-  - nosetests --nocapture
+  - nosetests --nocapture --with-coverage
   - source fireworks/tests/cmd_line_test.sh
+after_success:
+  - coveralls
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Nice way to track your test coverage. Took the liberty of setting up the `.coveragerc` file. Seems to be getting the right files, but maybe could be tuned to skip certain lines that one wishes to skip ( http://nedbatchelder.com/code/coverage/config.html ). Requires a Coveralls account for submission (free for open source). Uses Travis CI, but could be set up with another CI. See example output here ( https://coveralls.io/r/jakirkham/fireworks ).