### PR TITLE
Rapidfire switch back to cwd at the end.

### DIFF
--- a/fireworks/core/rocket_launcher.py
+++ b/fireworks/core/rocket_launcher.py
@@ -89,3 +89,4 @@ def rapidfire(launchpad, fworker=None, m_dir=None, nlaunches=0, max_loops=-1, sl
         time.sleep(sleep_time)
         num_loops += 1
         log_multi(l_logger, 'Checking for FWs to run...'.format(sleep_time))
+    os.chdir(curdir)

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -776,15 +776,18 @@ class LaunchPadRerunExceptionTest(unittest.TestCase):
 
     def test_except_details_on_rerun(self):
         rapidfire(self.lp, self.fworker, m_dir=MODULE_DIR)
+        self.assertEqual(os.getcwd(), MODULE_DIR)
         self.lp.rerun_fw(1)
         fw = self.lp.get_fw_by_id(1)
         self.assertEqual(fw.spec['_exception_details'], self.error_test_dict)
 
     def test_task_level_rerun(self):
         rapidfire(self.lp, self.fworker, m_dir=MODULE_DIR)
+        self.assertEqual(os.getcwd(), MODULE_DIR)
         self.lp.rerun_fws_task_level(1)
         self.lp.update_spec([1], {'skip_exception': True})
         rapidfire(self.lp, self.fworker, m_dir=MODULE_DIR)
+        self.assertEqual(os.getcwd(), MODULE_DIR)
         dirs = sorted(glob.glob(os.path.join(MODULE_DIR, "launcher_*")))
         self.assertEqual(self.lp.get_fw_by_id(1).state, 'COMPLETED')
         self.assertEqual(ExecutionCounterTask.exec_counter, 1)
@@ -793,9 +796,11 @@ class LaunchPadRerunExceptionTest(unittest.TestCase):
 
     def test_task_level_rerun_cp(self):
         rapidfire(self.lp, self.fworker, m_dir=MODULE_DIR)
+        self.assertEqual(os.getcwd(), MODULE_DIR)
         self.lp.rerun_fws_task_level(1, recover_mode="cp")
         self.lp.update_spec([1], {'skip_exception': True})
         rapidfire(self.lp, self.fworker, m_dir=MODULE_DIR)
+        self.assertEqual(os.getcwd(), MODULE_DIR)
         dirs = sorted(glob.glob(os.path.join(MODULE_DIR, "launcher_*")))
         self.assertEqual(self.lp.get_fw_by_id(1).state, 'COMPLETED')
         self.assertEqual(ExecutionCounterTask.exec_counter, 1)
@@ -804,10 +809,12 @@ class LaunchPadRerunExceptionTest(unittest.TestCase):
 
     def test_task_level_rerun_prev_dir(self):
         rapidfire(self.lp, self.fworker, m_dir=MODULE_DIR)
+        self.assertEqual(os.getcwd(), MODULE_DIR)
         self.lp.rerun_fws_task_level(1, recover_mode="prev_dir")
         self.lp.update_spec([1], {'skip_exception': True})
         rapidfire(self.lp, self.fworker, m_dir=MODULE_DIR)
         fw = self.lp.get_fw_by_id(1)
+        self.assertEqual(os.getcwd(), MODULE_DIR)
         self.assertEqual(fw.state, 'COMPLETED')
         self.assertEqual(fw.launches[0].launch_dir, fw.archived_launches[0].launch_dir)
         self.assertEqual(ExecutionCounterTask.exec_counter, 1)


### PR DESCRIPTION
Fixes materialsproject/fireworks#98. I have verified that the tests fail when my solution is not included. Also, this works when testing in workflows.