### PR TITLE
Workaround for issue materialsproject/fireworks#100

### DIFF
--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -687,6 +687,7 @@ class WorkflowFireworkStatesTest(unittest.TestCase):
             fw_cache_state = wf.fw_states[fw_id]
             self.assertEqual(fw_state, fw_cache_state)
 
+    @unittest.skip("Test fails spuriously.")
     def test_rerun_timed_fws(self):
         # Launch all firework in a separate process
         class RapidfireProcess(Process):


### PR DESCRIPTION
This is a workaround for issue materialsproject/fireworks#100. Until a better solution is found, skip the timed test with spurious failures.