### PR TITLE
Restore workaround for issue materialsproject/fireworks#100

### DIFF
--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -687,7 +687,7 @@ class WorkflowFireworkStatesTest(unittest.TestCase):
             fw_cache_state = wf.fw_states[fw_id]
             self.assertEqual(fw_state, fw_cache_state)
 
-    #@unittest.skip("Test fails spuriously.")
+    @unittest.skip("Test fails spuriously.")
     def test_rerun_timed_fws(self):
         # Launch all fireworks in a separate process
         class RapidfireProcess(Process):


### PR DESCRIPTION
As mentioned in issue ( materialsproject/fireworks#100 ),the test, `test_rerun_timed_fws`, still has spurious failures as evidenced by the most recent builds on master ( https://travis-ci.org/materialsproject/fireworks/builds/65300009 ). So, bringing back the workaround until the problem is better understood and the necessary fix applied.