### PR TITLE
add support for IBM LoadSharingFacility to common_adapter.py

### DIFF
--- a/fireworks/user_objects/queue_adapters/LoadSharingFacility_template.txt
+++ b/fireworks/user_objects/queue_adapters/LoadSharingFacility_template.txt
@@ -1,0 +1,13 @@
+#BSUB -n $${ntasks}
+#BSUB -W $${walltime}
+#BSUB -q $${queue}
+#BSUB -J $${job_name}
+#BSUB -o $${job_name}-%J.out
+#BSUB -e $${job_name}-%J.error
+
+$${pre_rocket}
+cd $${launch_dir}
+$${rocket_launch}
+$${post_rocket}
+
+# CommonAdapter (SLURM) completed writing Template

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -146,8 +146,8 @@ class CommonAdapter(QueueAdapterBase):
             #as an argument.  LoadSharingFacility doesn't handle the header section (queue name, nodes, etc)
             #when taking file arguments, so the file needs to be passed as stdin to make it work correctly.
             if self.q_type == 'LoadSharingFacility':
-                inputFile=open(script_file,'r')
-                p = subprocess.Popen([submit_cmd],stdin=inputFile,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+                with open(script_file,'r') as inputFile:
+                    p = subprocess.Popen([submit_cmd],stdin=inputFile,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
             else:
                 p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             p.wait()

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -33,6 +33,7 @@ class CommonAdapter(QueueAdapterBase):
         "SGE": "qsub",
         "SLURM": "sbatch",
         "LoadLeveler": "llsubmit"
+        "LoadSharingFacility": "bsub"
     }
 
     def __init__(self, q_type, q_name=None, template_file=None, **kwargs):
@@ -79,6 +80,9 @@ class CommonAdapter(QueueAdapterBase):
             return ['squeue', '-o "%u"', '-u', username]
         elif self.q_type == "LoadLeveler":
             return ['llq', '-u', username]
+        elif self.q_type == "LoadSharingFacility":
+            #use no header and the wide format so that there is one line per job, and display only running and pending jobs
+            return ['bjobs', '-p','-r','-o','jobID user queue','-noheader','-u',username]
         else:
             return ['qstat', '-u', username]
 
@@ -96,6 +100,9 @@ class CommonAdapter(QueueAdapterBase):
             else:
                 # last line is: "1 job step(s) in query, 0 waiting, ..."
                 return int(output_str.split('\n')[-2].split()[0])
+        if self.q_type == "LoadSharingFacility":
+                #Just count the number of lines
+                return len(output_str.split('\n'))
 
         count = 0
         for l in output_str.split('\n'):
@@ -135,8 +142,14 @@ class CommonAdapter(QueueAdapterBase):
         # submit the job
         try:
             cmd = [submit_cmd, script_file]
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE)
+            #For most of the queues handled by common_adapter, it's best to simply submit the file name
+            #as an argument.  LoadSharingFacility doesn't handle the header section (queue name, nodes, etc)
+            #when taking file arguments, so the file needs to be passed as stdin to make it work correctly.
+            if self.q_type == 'LoadSharingFacility':
+                inputFile=open(script_file,'r')
+                p = subprocess.Popen([submit_cmd],stdin=inputFile,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+            else:
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             p.wait()
 
             # grab the returncode. PBS returns 0 if the job was successful

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -32,7 +32,7 @@ class CommonAdapter(QueueAdapterBase):
         "PBS": "qsub",
         "SGE": "qsub",
         "SLURM": "sbatch",
-        "LoadLeveler": "llsubmit"
+        "LoadLeveler": "llsubmit",
         "LoadSharingFacility": "bsub"
     }
 


### PR DESCRIPTION
common_adapter.py currently supports IBM LoadLeveler, which has been replaced with IBM LoadSharingFacility (LSF).  

Adding support for LSF was pretty trivial; the only problem I found was that the job submission utility only processed the file headers (queue name, job name, etc) correctly when the file was read in through stdin (i.e. 'bsub < submissionfile').  This may be a problem with our local cluster installation; we currently use a custom wrapper that reads the file ahead of time and converts the header into command line arguments.  I don't think the proposed special-case for the submission (lines 140-145) would break support even if submitting as a file worked correctly on someone else's cluster.