### PR TITLE
fworker: fix query when user sets or-query

### DIFF
--- a/fireworks/core/fworker.py
+++ b/fireworks/core/fworker.py
@@ -59,7 +59,12 @@ class FWorker(FWSerializable):
     @property
     def query(self):
         q = self._query
-        q['$or'] = [{"spec._fworker": {"$exists": False}}, {"spec._fworker": None}, {"spec._fworker": self.name}]
+        fworker_check = [{"spec._fworker": {"$exists": False}}, {"spec._fworker": None}, {"spec._fworker": self.name}]
+        if '$or' in q:
+            # TODO: cover case where user sets an $and query?
+            q['$and'] = [{'$or': q.pop('$or')}, {'$or': fworker_check}]
+        else:
+            q['$or'] = fworker_check
         if self.category:
             q['spec._category'] = self.category
         return q


### PR DESCRIPTION
A user's `$or` query is overwritten in `fworker.query` and hence effectively ignored. This pull request fixes this issue by combining the user's `$or` query with the internal fworker check through an `$and` query.