### PR TITLE
SLURM_template: request login shell in shebang line

### DIFF
--- a/fireworks/user_objects/queue_adapters/SLURM_template.txt
+++ b/fireworks/user_objects/queue_adapters/SLURM_template.txt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -l
 
 #SBATCH --nodes=$${nodes}
 #SBATCH --ntasks=$${ntasks}


### PR DESCRIPTION
We noticed when testing SLURM on NERSC's Carver that the submit script will not be able to load/find the necessary module unless a login shell is requested in the shebang line. This pull requests fixes it for the SLURM template but it might be necessary for the other templates, too.