### PR TITLE
Cast query arg to lpad report from str to dict

### DIFF
--- a/fireworks/features/fw_report.py
+++ b/fireworks/features/fw_report.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import ast
 from collections import OrderedDict
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
@@ -44,7 +45,7 @@ class FWReport():
         coll = self.db[coll]
 
         pipeline = []
-        match_q = additional_query if additional_query else {}
+        match_q = ast.literal_eval(additional_query) if additional_query else {}
         if num_intervals:
             now_time = datetime.utcnow()
             start_time = now_time - relativedelta(**{interval:num_intervals})


### PR DESCRIPTION
I'd like to run reports like
```bash
$ lpad report -i months -q '{"spec.mpsnl.about.remarks": "MP user submission"}'
```
but it seems the query arg is left as a `str`, so I get an `AttributeError: 'str' object has no attribute 'update'` [here](https://github.com/materialsproject/fireworks/blob/f112342dd26f06d5b4622f117ca2cc79679e7095/fireworks/features/fw_report.py#L52).

My PR fixes this issue for me so that I can run the above line with success.