### PR TITLE
removed conditional on returning updated_ids in append_wf

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -857,9 +857,8 @@ class Workflow(FWSerializable):
                             for mod in m_launch.action.mod_spec:
                                 apply_mod(mod, new_wf.id_fw[root_id].spec)
 
-        if refresh_wf:
-            for new_fw in new_wf.fws:
-                updated_ids = self.refresh(new_fw.fw_id, set(updated_ids))
+        for new_fw in new_wf.fws:
+            updated_ids = self.refresh(new_fw.fw_id, set(updated_ids))
 
         return updated_ids
 


### PR DESCRIPTION
I'm having some trouble with fireworks that append new fireworks to a workflow as a result of the changes in commit 12d4958.  I get the error below when doing Add Electronic Structure Task, for example.  It seems like removing the refresh_wfs conditional near the end of append_wfs in fireworks.py fixes the issue, but there may be a more appropriate fix.

"2015-10-26 19:08:02,600 INFO Task completed: Add Electronic Structure Task v2
Traceback (most recent call last):
  File "/global/u1/m/montoyjh/jhm_elastic/codes/fireworks/fireworks/core/rocket.py", line 298, in run
    lp.complete_launch(launch_id, m_action, final_state)
  File "/global/u1/m/montoyjh/jhm_elastic/codes/fireworks/fireworks/core/launchpad.py", line 886, in complete_launch
    self._refresh_wf(fw_id)
  File "/global/u1/m/montoyjh/jhm_elastic/codes/fireworks/fireworks/core/launchpad.py", line 1017, in _refresh_wf
    self._update_wf(wf, updated_ids)
  File "/global/u1/m/montoyjh/jhm_elastic/codes/fireworks/fireworks/core/launchpad.py", line 1038, in _update_wf
    wf = wf.to_db_dict()
  File "/global/u1/m/montoyjh/jhm_elastic/codes/fireworks/fireworks/core/firework.py", line 996, in to_db_dict
    m_dict['state'] = self.state
  File "/global/u1/m/montoyjh/jhm_elastic/codes/fireworks/fireworks/core/firework.py", line 719, in state
    leaf_states = [self.fw_states[fw_id] for fw_id in self.leaf_fw_ids]
KeyError: 17"