### PR TITLE
Add view for wf metadata queries

### DIFF
--- a/fireworks/flask_site/app.py
+++ b/fireworks/flask_site/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, request, jsonify
+from flask import redirect, url_for, abort
 from fireworks import Firework
 from fireworks.utilities.fw_serializers import DATETIME_HANDLER
 from pymongo import DESCENDING
@@ -164,6 +165,37 @@ def wf_state(state):
     all_states = STATES
     return render_template('wf_state.html', **locals())
 
+@app.route("/wf/metadata/<key>/<value>/", defaults={"state": "total"})
+@app.route("/wf/metadata/<key>/<value>/<state>/")
+def wf_metadata_find(key, value, state):
+    db = lp.workflows
+    try:
+        value = int(value)
+    except ValueError:
+        pass
+    q = {'metadata.{}'.format(key): value}
+    state_mixin = {} if state == "total" else {"state": state}
+    q.update(state_mixin)
+    wf_count = lp.get_wf_ids(query=q, count_only=True)
+    if wf_count == 0:
+        abort(404)
+    elif wf_count == 1:
+        doc = db.find_one(q, {'nodes': 1, '_id': 0})
+        fw_id = doc['nodes'][0]
+        return redirect(url_for('wf_details', wf_id=fw_id))
+    else:
+        try:
+            page = int(request.args.get('page', 1))
+        except ValueError:
+            page = 1
+        rows = list(db.find(q).sort([('_id', DESCENDING)]).\
+                    skip(page - 1).limit(PER_PAGE))
+        for r in rows:
+            r["fw_id"] = r["nodes"][0]
+        pagination = Pagination(page=page, total=wf_count,
+                                record_name='workflows', per_page=PER_PAGE)
+        all_states = STATES
+        return render_template('wf_metadata.html', **locals())
 
 if __name__ == "__main__":
     app.run(debug=True, port=8080)

--- a/fireworks/flask_site/templates/wf_metadata.html
+++ b/fireworks/flask_site/templates/wf_metadata.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{% block title %}{{key}}={{value}} {{ state }} Workflows Index{% endblock %}
+
+{% block content %}
+<h3 class="text-center">{{ '{:,}'.format(wf_count) }} {{ state|lower }} Workflow{{ wf_count|pluralize }} for {{ key }}={{ value }}</h3>
+
+<!-- FILTERS / NAVIGATION -->
+<div class="pull-down">
+  <ul class="inline">
+    {% for s in all_states %}
+    <li>
+      <a href="/wf/metadata/{{key}}/{{value}}/{{s}}">
+        <span class="label {{s}}">
+          {{ s }}
+        </span>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+
+<!-- TABLE -->
+<table class="table table-bordered">
+  <tr><th colspan="2">{{ state }} Workflows</th></tr>
+  <tr>
+    <th>ID</th>
+    <th>Name</th>
+    <th>Created On</th>
+  </tr>
+  {% for row in rows %}
+  <tr>
+    <td><center><a href="/wf/{{ row.fw_id }}">{{ row.fw_id }}</a></center></td>
+    <td>{{ row.name }}</td>
+    <td>{{ row.created_on }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{{ pagination.links|safe }}
+
+{% endblock %}


### PR DESCRIPTION
* Takes a key/value pair, and optionally a state
* If only one result, redirect to wf_details view
* If multiple results, load specialization of wf_state view

The onus would be on users to ensure [appropriate indexes](https://pythonhosted.org/FireWorks/performance_tutorial.html#how-to-add-an-index-to-workflow-metadata).

Intended immediate application: `/wf/metadata/submission_id/\d+/` links to workflows spawned by materialsproject.org user submissions.