### PR TITLE
small improvements for offline mode

### DIFF
--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -21,9 +21,11 @@ import filecmp
 from fireworks import Firework, Workflow, LaunchPad, FWorker
 from fw_tutorials.dynamic_wf.addmod_task import AddModifyTask
 from fireworks.core.rocket_launcher import rapidfire, launch_rocket
+from fireworks.queue.queue_launcher import setup_offline_job
 from fireworks.user_objects.firetasks.script_task import ScriptTask, PyTask
 from fireworks.core.tests.tasks import ExceptionTestTask, ExecutionCounterTask, SlowAdditionTask, WaitWFLockTask
 import fireworks.fw_config
+from monty.os import cd
 
 TESTDB_NAME = 'fireworks_unittest'
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -1012,6 +1014,86 @@ class WFLockTest(unittest.TestCase):
 
         self.assertEqual(fast_fw.state, 'FIZZLED')
 
+
+class LaunchPadOfflineTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.lp = None
+        cls.fworker = FWorker()
+        try:
+            cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl='ERROR')
+            cls.lp.reset(password=None, require_password=False)
+        except:
+            raise unittest.SkipTest('MongoDB is not running in localhost:27017! Skipping tests.')
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.lp:
+            cls.lp.connection.drop_database(TESTDB_NAME)
+
+    def setUp(self):
+        fireworks.core.firework.EXCEPT_DETAILS_ON_RERUN = True
+
+        self.error_test_dict = {'error': 'description', 'error_code': 1}
+        fw = Firework(ScriptTask.from_str(
+            'echo "test offline"',
+            {'store_stdout':True}), name="offline_fw", fw_id=1)
+        self.lp.add_wf(fw)
+
+        self.launch_dir = os.path.join(MODULE_DIR, "launcher_offline")
+        os.makedirs(self.launch_dir)
+
+        self.old_wd = os.getcwd()
+
+    def tearDown(self):
+        self.lp.reset(password=None, require_password=False)
+        # Delete launch locations
+        if os.path.exists(os.path.join('FW.json')):
+            os.remove('FW.json')
+        os.chdir(self.old_wd)
+        for ldir in glob.glob(os.path.join(MODULE_DIR, "launcher_*")):
+            shutil.rmtree(ldir, ignore_errors=True)
+
+    def test__recover_completed(self):
+        fw, launch_id = self.lp.reserve_fw(self.fworker, self.launch_dir)
+        fw = self.lp.get_fw_by_id(1)
+        with cd(self.launch_dir):
+            setup_offline_job(self.lp, fw, launch_id)
+
+            # launch rocket without launchpad to trigger offline mode
+            launch_rocket(launchpad=None, fworker=self.fworker, fw_id=1)
+
+        self.assertIsNone(self.lp.recover_offline(launch_id))
+
+        fw = self.lp.get_fw_by_id(launch_id)
+
+        self.assertEqual(fw.state, 'COMPLETED')
+
+
+    def test_recover_errors(self):
+        fw, launch_id = self.lp.reserve_fw(self.fworker, self.launch_dir)
+        fw = self.lp.get_fw_by_id(1)
+        with cd(self.launch_dir):
+            setup_offline_job(self.lp, fw, launch_id)
+
+        # remove the directory to cause an exception
+        shutil.rmtree(self.launch_dir)
+
+        # recover ignoring errors
+        self.assertIsNotNone(self.lp.recover_offline(launch_id, ignore_errors=True, print_errors=True))
+
+        fw = self.lp.get_fw_by_id(launch_id)
+
+        self.assertEqual(fw.state, 'RESERVED')
+
+        #fizzle
+        self.assertIsNotNone(self.lp.recover_offline(launch_id, ignore_errors=False))
+
+        fw = self.lp.get_fw_by_id(launch_id)
+
+        self.assertEqual(fw.state, 'FIZZLED')
+                
 
 if __name__ == '__main__':
     unittest.main()

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -21,9 +21,10 @@ import yaml
 
 from fireworks.fw_config import RESERVATION_EXPIRATION_SECS, \
     RUN_EXPIRATION_SECS, PW_CHECK_NUM, MAINTAIN_INTERVAL, CONFIG_FILE_DIR, \
-    LAUNCHPAD_LOC, WEBSERVER_PORT, WEBSERVER_HOST
+    LAUNCHPAD_LOC, FWORKER_LOC, WEBSERVER_PORT, WEBSERVER_HOST
 from fireworks.core.launchpad import LaunchPad
 from fireworks.core.firework import Workflow, Firework
+from fireworks.core.fworker import FWorker
 from fireworks import __version__ as FW_VERSION
 from fireworks import FW_INSTALL_DIR
 from fireworks.user_objects.firetasks.script_task import ScriptTask
@@ -441,16 +442,20 @@ def add_scripts(args):
 
 def recover_offline(args):
     lp = get_lp(args)
+    fworker_name = FWorker.from_file(args.fworker_file).name if args.fworker_file else None
     failed_fws = []
-    recovered = 0
-    for l in lp.offline_runs.find({"completed": False, "deprecated": False}, {"launch_id": 1}):
-        fw = lp.recover_offline(l['launch_id'], args.ignore_errors)
-        if fw:
-            failed_fws.append(fw)
-        else:
-            recovered += 1
+    recovered_fws = []
 
-    lp.m_logger.info("FINISHED recovering offline runs. {} job(s) recovered".format(recovered))
+    for l in lp.offline_runs.find({"completed": False, "deprecated": False}, {"launch_id": 1, "fw_id":1}):
+        if fworker_name and lp.launches.count({"launch_id": l["launch_id"], "fworker.name": fworker_name}) == 0:
+            continue
+        fw = lp.recover_offline(l['launch_id'], args.ignore_errors, args.print_errors)
+        if fw:
+            failed_fws.append(l['fw_id'])
+        else:
+            recovered_fws.append(l['fw_id'])
+
+    lp.m_logger.info("FINISHED recovering offline runs. {} job(s) recovered: {}".format(len(recovered_fws), recovered_fws))
     if failed_fws:
         lp.m_logger.info("FAILED to recover offline fw_ids: {}".format(failed_fws))
 
@@ -782,6 +787,8 @@ def lpad():
 
     recover_parser = subparsers.add_parser('recover_offline', help='recover offline workflows')
     recover_parser.add_argument('-i', '--ignore_errors', help='ignore errors', action='store_true')
+    recover_parser.add_argument('-w', '--fworker_file', help='path to fworker file. An empty string will match all the workers', default=FWORKER_LOC)
+    recover_parser.add_argument('-pe', '--print-errors', help='print errors', action='store_true')
     recover_parser.set_defaults(func=recover_offline)
 
     forget_parser = subparsers.add_parser('forget_offline', help='forget offline workflows')


### PR DESCRIPTION
- only launches for worker specified by -w will be recovered (one needs to run the command on the actual worker anyway)
- recover_offline can optionally print the exceptions
- fix: recover_offline sets the state of the FW to running when needed
- tests