### PR TITLE
FileTransferTask bugfixes, added user parameter

### DIFF
--- a/fireworks/user_objects/firetasks/fileio_tasks.py
+++ b/fireworks/user_objects/firetasks/fileio_tasks.py
@@ -96,7 +96,7 @@ class FileTransferTask(FireTaskBase):
             import paramiko
             ssh = paramiko.SSHClient()
             ssh.load_host_keys(expanduser(os.path.join("~", ".ssh", "known_hosts")))
-            ssh.connect(self['server'], username=self.get('user'), key_filename=self.get['key_filename'])
+            ssh.connect(self['server'], username=self.get('user'), key_filename=self.get('key_filename'))
             sftp = ssh.open_sftp()
 
         for f in self["files"]:
@@ -117,7 +117,10 @@ class FileTransferTask(FireTaskBase):
                             if os.path.isfile(os.path.join(src,f)):
                                 sftp.put(os.path.join(src, f), os.path.join(dest, f))
                     else:
-                        sftp.put(src, dest)
+                        if not self._rexists(sftp, dest):
+                            sftp.mkdir(dest)
+
+                        sftp.put(src, os.path.join(dest, os.path.basename(src)))
 
                 else:
                     if 'dest' in f:

--- a/fireworks/user_objects/firetasks/fileio_tasks.py
+++ b/fireworks/user_objects/firetasks/fileio_tasks.py
@@ -69,6 +69,7 @@ class FileTransferTask(FireTaskBase):
         - dest: (str) destination directory, if not specified within files parameter
     Optional params:
         - server: (str) server host for remote transfer
+        - user: (str) user to authenticate with on remote server
         - key_filename: (str) optional SSH key location for remote transfer
     """
     _fw_name = 'FileTransferTask'
@@ -95,7 +96,7 @@ class FileTransferTask(FireTaskBase):
             import paramiko
             ssh = paramiko.SSHClient()
             ssh.load_host_keys(expanduser(os.path.join("~", ".ssh", "known_hosts")))
-            ssh.connect(self['server'], key_filename=self.get['key_filename'])
+            ssh.connect(self['server'], username=self.get('user'), key_filename=self.get['key_filename'])
             sftp = ssh.open_sftp()
 
         for f in self["files"]:


### PR DESCRIPTION
Fixes [a misuse of `get`](https://github.com/materialsproject/fireworks/blob/master/fireworks/user_objects/firetasks/fileio_tasks.py#L98) in the `FileTransferTask` relevant for remote transfers. Also ensures that if `src` is a file, `dest` is still interpreted as a directory (as it should according to the class docstring).

Additionally, adds a `user` parameter for specifying the username to authenticate against on the remote server.

If this is too many things in one PR, I'm happy to split them up.