### PR TITLE
Can now make a fresh copy of an existing Workflow.

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -30,7 +30,7 @@ Zach Ulissi added support for IBM LoadSharing facility.
 
 William Scullin added ALCF Cobalt support and helped stomp bugs.
 
-Brian Foster, kpoman, jakirkham, Ganesh Panchapakesan, Patrick Huck, Donny Winston, Joey Montoya, Henrik Rusche, David Cossey, David Doston, specter119, and Felix Zapata helped stomp bugs and provide improvements.
+Brian Foster, kpoman, jakirkham, Ganesh Panchapakesan, Patrick Huck, Donny Winston, Joey Montoya, Henrik Rusche, David Cossey, David Dotson, specter119, and Felix Zapata helped stomp bugs and provide improvements.
 
 Thanks to Marat Valiev for suggesting Jinja2 as a lightweight templating alternative to Django and Stephen Bailey and Deborah Bard for helpful discussions.
 

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -21,7 +21,6 @@ from collections import defaultdict, OrderedDict
 import abc
 from datetime import datetime
 import os
-import copy
 import pprint
 
 from monty.io import reverse_readline, zopen

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -1078,35 +1078,39 @@ class Workflow(FWSerializable):
         return m_launch
 
     @classmethod
-    def from_Workflow(cls, wflow):
-        """Create a fresh Workflow from a given one.
+    def from_wflow(cls, wflow):
+        """Create a fresh Workflow from an existing one.
 
         """
-        new_wf = Workflow([copy.deepcopy(fw) for fw in wflow.fws],
-                          links_dict=wflow.links,
-                          metadata=wflow.metadata,
-                          name=wflow.name)
 
-        # need to give Fireworks new ids
-        old_new = {} # mapping between old and new Firework ids
-
-        for fw_id, fw in new_wf.id_fw.items():
-            global NEGATIVE_FWID_CTR
-            NEGATIVE_FWID_CTR -= 1
-            new_id = NEGATIVE_FWID_CTR
-
-            old_new[fw_id] = new_id
-            fw.fw_id = new_id
-        
-        new_wf._reassign_ids(old_new)
-
-        # reset states
-        for fw in new_wf.fws:
-            fw.state = 'WAITING'
-
-        new_wf.fw_states = {key: new_wf.id_fw[key].state for key in new_wf.id_fw}
+        new_wf = Workflow.from_dict(wflow.to_dict())
+        new_wf.reset(reset_ids=True)
 
         return new_wf
+
+    def reset(self, reset_ids=False):
+        """Reset the states of all Fireworks in this workflow to 'WAITING'.
+
+        :param rest_ids: (bool) if ``True``, give each Firework a new id.
+
+        """
+        if rest_ids:
+            old_new = {} # mapping between old and new Firework ids
+            for fw_id, fw in self.id_fw.items():
+                global NEGATIVE_FWID_CTR
+                NEGATIVE_FWID_CTR -= 1
+                new_id = NEGATIVE_FWID_CTR
+
+                old_new[fw_id] = new_id
+                fw.fw_id = new_id
+        
+            self._reassign_ids(old_new)
+
+        # reset states
+        for fw in self.fws:
+            fw.state = 'WAITING'
+
+        self.fw_states = {key: self.id_fw[key].state for key in self.id_fw}
 
     @classmethod
     def from_dict(cls, m_dict):

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -1090,10 +1090,10 @@ class Workflow(FWSerializable):
     def reset(self, reset_ids=False):
         """Reset the states of all Fireworks in this workflow to 'WAITING'.
 
-        :param rest_ids: (bool) if ``True``, give each Firework a new id.
+        :param reset_ids: (bool) if ``True``, give each Firework a new id.
 
         """
-        if rest_ids:
+        if reset_ids:
             old_new = {} # mapping between old and new Firework ids
             for fw_id, fw in self.id_fw.items():
                 global NEGATIVE_FWID_CTR

--- a/fireworks/core/tests/test_firework.py
+++ b/fireworks/core/tests/test_firework.py
@@ -51,6 +51,7 @@ class WorkflowTest(unittest.TestCase):
         fws = []
         for i in range(5):
             fw = Firework([PyTask(func="print", args=[i])], fw_id=i)
+
             fws.append(fw)
         wf = Workflow(fws, links_dict={0: [1, 2, 3], 1: [4], 2: [4]})
         self.assertIsInstance(wf, Workflow)
@@ -58,6 +59,34 @@ class WorkflowTest(unittest.TestCase):
                           links_dict={0: [1, 2, 3], 1: [4], 100: [4]})
         self.assertRaises(ValueError, Workflow, fws,
                           links_dict={0: [1, 2, 3], 1: [4], 2: [100]})
+
+
+    def test_copy(self):
+        """Test that we can produce a copy of a Workflow but that the copy
+        has unique fw_ids.
+
+        """
+        fws = []
+        for i in range(5):
+            fw = Firework([PyTask(func="print", args=[i])], fw_id=i,
+                          name=i)
+            fws.append(fw)
+
+        wf = Workflow(fws, links_dict={0: [1, 2, 3], 1: [4], 2: [4]})
+
+        wf_copy = Workflow.from_wflow(wf)
+        
+        # now we compare to the original to make sure dependencies are same.
+        # have to do gymnastics because ids will NOT be the same
+        # but names are retained
+        for fw in wf_copy.fws:
+            children = wf_copy.links.get(fw.fw_id, list())
+            orig_id = fw.name
+
+            orig_children = wf.links.get(orig_id, list())
+
+            for child_id, orig_child_id in zip(children, orig_children):
+                self.assertEqual(orig_child_id, wf_copy.id_fw[child_id].name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are occasions in which a new Workflow needs to be created from an
existing one, but with updated Firework ids to ensure no collisions with
any Workflows it is appended to. Such collisions can occur when a
Workflow has been serialized and stored within a Firework spec, then
appended by that Firework to the Workflow it is a part of (as an ``addition``).
The result of these collisions are often malformed links.

Building a fresh Workflow from that stored avoids this problem, since
the member Fireworks are given fresh ids that have not been used within
the current session.