### PR TITLE
Feature filetransfer retry

### DIFF
--- a/fireworks/user_objects/firetasks/fileio_tasks.py
+++ b/fireworks/user_objects/firetasks/fileio_tasks.py
@@ -88,6 +88,7 @@ class FileTransferTask(FireTaskBase):
     def run_task(self, fw_spec):
         shell_interpret = self.get('shell_interpret', True)
         ignore_errors = self.get('ignore_errors')
+        retry = self.get('retry')
         mode = self.get('mode', 'move')
 
         if mode == 'rtransfer':
@@ -133,10 +134,13 @@ class FileTransferTask(FireTaskBase):
 
             except:
                 traceback.print_exc()
-                if not ignore_errors:
+                if retry:
+                    self.run_task(fw_spec)
+                elif not ignore_errors:
                     raise ValueError(
                         "There was an error performing operation {} from {} "
                         "to {}".format(mode, self["files"], self["dest"]))
+
         if mode == 'rtransfer':
             sftp.close()
             ssh.close()

--- a/fireworks/user_objects/firetasks/fileio_tasks.py
+++ b/fireworks/user_objects/firetasks/fileio_tasks.py
@@ -91,7 +91,7 @@ class FileTransferTask(FireTaskBase):
         shell_interpret = self.get('shell_interpret', True)
         ignore_errors = self.get('ignore_errors')
         max_retry = self.get('max_retry', 0)
-        retry_delay = self.get('max_retry', 10)
+        retry_delay = self.get('retry_delay', 10)
         mode = self.get('mode', 'move')
 
         if mode == 'rtransfer':


### PR DESCRIPTION
Added ``retry`` option to ``FileTransferTask``. It's a bit crude in that it just runs ``self.run_task`` again if the `try` block fails and the ``retry`` option is ``True``. As written it will keep trying until the recursion limit is reached.

Happy to adjust the way this is implemented to make it less crude. At the moment this is a (useful) hack I use to guard against remote transfer failures, which are frequent enough (for me) as to make this a must-have.