### PR TITLE
Fixed problem with ssl_ca_file ... if it is None, just dont pass it t…

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -122,6 +122,9 @@ class LaunchPad(FWSerializable):
         self.wf_user_indices = wf_user_indices if wf_user_indices else []
 
         # get connection
+        # WARNING: Note that there might be some problem with the ssl feature for some combination versions of MongoDB
+        # and pymongo such that if you do not use ssl (using ssl_ca_file = None), fireworks can't connect to the
+        # Mongo database. This is why there is the following if condition. DO NOT REMOVE THIS IF CONDITION!
         if self.ssl_ca_file is not None:
             self.connection = MongoClient(host, port, j=True, ssl_ca_certs=self.ssl_ca_file,
                                           socketTimeoutMS=MONGO_SOCKET_TIMEOUT_MS)

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -122,8 +122,12 @@ class LaunchPad(FWSerializable):
         self.wf_user_indices = wf_user_indices if wf_user_indices else []
 
         # get connection
-        self.connection = MongoClient(host, port, j=True, ssl_ca_certs=self.ssl_ca_file,
-                                        socketTimeoutMS=MONGO_SOCKET_TIMEOUT_MS)
+        if self.ssl_ca_file is not None:
+            self.connection = MongoClient(host, port, j=True, ssl_ca_certs=self.ssl_ca_file,
+                                          socketTimeoutMS=MONGO_SOCKET_TIMEOUT_MS)
+        else:
+            self.connection = MongoClient(host, port, j=True,
+                                          socketTimeoutMS=MONGO_SOCKET_TIMEOUT_MS)
         self.db = self.connection[name]
         if username:
             self.db.authenticate(username, password)

--- a/fireworks/queue/queue_launcher.py
+++ b/fireworks/queue/queue_launcher.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-import datetime
+from datetime import datetime
 
 """
 This module is used to submit jobs to a queue on a cluster. It can submit a single job, \


### PR DESCRIPTION
…o MongoClient.

For some reason, this did not work ... maybe due to (old) version of MongoDB at our site (2.4) or version of pymongo (3.2.2) or combination of the two ? Anyway this fixes the problem without removing the ssl_ca feature.