### PR TITLE
Fix SGE qlaunch rapidfire --maxjobs_queue detection

### DIFF
--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -136,9 +136,9 @@ class CommonAdapter(QueueAdapterBase):
             #Just count the number of lines
             return len(output_str.split('\n'))
         if self.q_type == "SGE":
-            # output string has states and separator as first two lines
-            # one more due to trailing '\n' gets the right number
-            return len(output_str.split('\n')) - 3
+            # want only lines that include username;
+            # this will exclude e.g. header lines
+            return len([l for l in output_str.split('\n') if username in l])
 
         count = 0
         for l in output_str.split('\n'):

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -109,7 +109,7 @@ class CommonAdapter(QueueAdapterBase):
             header="JobId:User:Queue:Jobname:Nodes:Procs:Mode:WallTime:State:RunTime:Project:Location"
             status_cmd.extend(['--header', header, '-u', username])
         elif self.q_type == 'SGE':
-            status_cmd.extend(['-q', self.q_name, '-u', username])
+            status_cmd.extend(['-q', self['queue'], '-u', username])
         else:
             status_cmd.extend(['-u', username])
 
@@ -137,7 +137,8 @@ class CommonAdapter(QueueAdapterBase):
             return len(output_str.split('\n'))
         if self.q_type == "SGE":
             # output string has states and separator as first two lines
-            return len(output_str.split('\n')) - 2
+            # one more due to trailing '\n' gets the right number
+            return len(output_str.split('\n')) - 3
 
         count = 0
         for l in output_str.split('\n'):

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -108,6 +108,8 @@ class CommonAdapter(QueueAdapterBase):
         elif self.q_type == "Cobalt":
             header="JobId:User:Queue:Jobname:Nodes:Procs:Mode:WallTime:State:RunTime:Project:Location"
             status_cmd.extend(['--header', header, '-u', username])
+        elif self.q_type == 'SGE':
+            status_cmd.extend(['-q', self.q_name, '-u', username])
         else:
             status_cmd.extend(['-u', username])
 
@@ -131,8 +133,11 @@ class CommonAdapter(QueueAdapterBase):
                 # last line is: "1 job step(s) in query, 0 waiting, ..."
                 return int(output_str.split('\n')[-2].split()[0])
         if self.q_type == "LoadSharingFacility":
-                #Just count the number of lines
-                return len(output_str.split('\n'))
+            #Just count the number of lines
+            return len(output_str.split('\n'))
+        if self.q_type == "SGE":
+            # output string has states and separator as first two lines
+            return len(output_str.split('\n')) - 2
 
         count = 0
         for l in output_str.split('\n'):


### PR DESCRIPTION
Using ``qlaunch rapidfire --maxjobs_queue <NUM>`` for launching rockets to an SGE queue did not properly detect the number of jobs in the queue. This is because by default the ``qstat`` output doesn't include the queue assignment for jobs that are not yet running, so in the case where ``<NUM>`` is greater than the number of jobs actually running, jobs will continue to be submitted (especially for ``--nlaunches infinite``) well beyond ``<NUM>``.

This PR adds a special case (as already exist for some other resource managers) for SGE, changing the ``qstat`` call used by the qlauncher to specify the queue name *and* the user, then counting the lines present. 

SGE does not leave completed jobs in the ``qstat`` output to my knowledge (doesn't happen on our installation, but if anyone knows otherwise we can add exclusions in the parsing), so we just do simple line counts of the resulting output from the ``qstat`` call.