### PR TITLE
open compressed files in textmode to ensure py3k compatibility

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -358,7 +358,7 @@ class Tracker(FWSerializable, object):
             m_file = zpath(m_file)
 
         if os.path.exists(m_file):
-            with zopen(m_file) as f:
+            with zopen(m_file, "rt") as f:
                 for l in reverse_readline(f):
                     lines.append(l)
                     if len(lines) == self.nlines:


### PR DESCRIPTION
wrap the gzipfile object in an io.TextIOWrapper instance so that python3 projects can use the trackers.