### PR TITLE
Add Options to Leave Head Node Out in Job Packing

### DIFF
--- a/fireworks/scripts/mlaunch_run.py
+++ b/fireworks/scripts/mlaunch_run.py
@@ -46,6 +46,8 @@ def mlaunch():
 
     parser.add_argument('--nodefile', help='nodefile name or environment variable name containing the node file name (for populating FWData only)', default=None, type=str)
     parser.add_argument('--ppn', help='processors per node (for populating FWData only)', default=1, type=int)
+    parser.add_argument('--exclude_current_node', help="Don't use the script launching node as compute node",
+                        action="store_true")
 
     args = parser.parse_args()
 
@@ -72,7 +74,8 @@ def mlaunch():
             total_node_list = [line.strip() for line in f.readlines()]
 
     launch_multiprocess(launchpad, fworker, args.loglvl, args.nlaunches, args.num_jobs,
-                        args.sleep, total_node_list, args.ppn, timeout=args.timeout)
+                        args.sleep, total_node_list, args.ppn, timeout=args.timeout,
+                        exclude_current_node=args.exclude_current_node)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
An option to exclude head node from compute node list is added to mlaunch. As MOM node is no longer available on Edison/Cori, heave jobs, e.g. VASP will also run on the head node. this option will help to reduce the presure on head node and therefore improve computational efficiecy if many nodes are used. By default, head node is not excluded. i.e. keep the node list as is.