### PR TITLE
Adds Tracker to core modules available to import from top-level fireworks namespace

### DIFF
--- a/fireworks/__init__.py
+++ b/fireworks/__init__.py
@@ -7,7 +7,7 @@ FW_INSTALL_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # E.g., you can now do "from fireworks import Firework", instead of from
 # "fireworks.core.firework import Firework".
 from fireworks.core.firework import FireTaskBase, Firework, Launch, Workflow, \
-    FWAction
+    FWAction, Tracker
 from fireworks.core.fworker import FWorker
 from fireworks.core.launchpad import LaunchPad
 from fireworks.utilities.fw_utilities import explicit_serialize


### PR DESCRIPTION
Per Rasmus Karlsson's recent e-mail to fireworkflows mailing list, imports Tracker in fireworks.__init__ so it can be imported from fireworks directly for convenience.