### PR TITLE
Qlaunch fw

### DIFF
--- a/docs/priority_tutorial.rst
+++ b/docs/priority_tutorial.rst
@@ -7,6 +7,8 @@ You might want to control the order in which your FireWorks are run. Setting job
 * You can assign any numerical value to the priority, including negative numbers and decimals. Higher priorities are run first.
 
  * FireWorks with *any* value of priority will be run before jobs without a priority defined. If two FireWorks have the same priority, one of those jobs will be chosen randomly (you can also choose FIFO and FILO ordering for equal-priority FireWorks via the :doc:`FW config </config_tutorial>`).
+ 
+ * You can launch specific fireworks from the command line via `rlaunch singleshot -f FW_ID` or `qlaunch -r singleshot -f FW_ID`.
 
 Set job priority using the command line after adding FWs
 ========================================================

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -834,7 +834,7 @@ class LaunchPad(FWSerializable):
             all_launch_ids.extend(l['launches'])
         return all_launch_ids
 
-    def reserve_fw(self, fworker, launch_dir, host=None, ip=None):
+    def reserve_fw(self, fworker, launch_dir, host=None, ip=None, fw_id=None):
         """
         Checkout the next ready firework and mark the launch reserved.
 
@@ -843,11 +843,12 @@ class LaunchPad(FWSerializable):
             launch_dir (str): path to the launch directory.
             host (str): hostname
             ip (str): ip address
+            fw_id (int): fw_id to be reserved, if desired
 
         Returns:
             (Firework, int): the checked out firework and the new launch id
         """
-        return self.checkout_fw(fworker, launch_dir, host=host, ip=ip, state="RESERVED")
+        return self.checkout_fw(fworker, launch_dir, host=host, ip=ip, fw_id=fw_id, state="RESERVED")
 
     def get_fw_ids_from_reservation_id(self, reservation_id):
         """

--- a/fireworks/queue/queue_launcher.py
+++ b/fireworks/queue/queue_launcher.py
@@ -31,7 +31,8 @@ __date__ = 'Dec 12, 2012'
 
 
 def launch_rocket_to_queue(launchpad, fworker, qadapter, launcher_dir='.', reserve=False,
-                           strm_lvl='INFO', create_launcher_dir=False, fill_mode=False):
+                           strm_lvl='INFO', create_launcher_dir=False, fill_mode=False,
+                           fw_id=None):
     """
     Submit a single job to the queue.
 
@@ -68,12 +69,16 @@ def launch_rocket_to_queue(launchpad, fworker, qadapter, launcher_dir='.', reser
     if fill_mode and reserve:
         raise ValueError("Fill_mode cannot be used in conjunction with reserve mode!")
 
+    if fw_id and not reserve:
+        raise ValueError("qlaunch for specific fireworks may only be used in reservation mode.")
+
     if fill_mode or launchpad.run_exists(fworker):
         launch_id = None
         try:
             if reserve:
-                l_logger.debug('finding a FW to reserve...')
-                fw, launch_id = launchpad.reserve_fw(fworker, launcher_dir)
+                if fw_id:
+                    l_logger.debug('finding a FW to reserve...')
+                fw, launch_id = launchpad.reserve_fw(fworker, launcher_dir, fw_id=fw_id)
                 if not fw:
                     l_logger.info('No jobs exist in the LaunchPad for submission to queue!')
                     return False

--- a/fireworks/scripts/qlaunch_run.py
+++ b/fireworks/scripts/qlaunch_run.py
@@ -107,14 +107,13 @@ def qlaunch():
     parser.add_argument('-s', '--silencer', help='shortcut to mute log messages', action='store_true')
     parser.add_argument('-r', '--reserve', help='reserve a fw', action='store_true')
     parser.add_argument('-l', '--launchpad_file', help='path to launchpad file', default=LAUNCHPAD_LOC)
-    parser.add_argument('-f', '--fw_id', help='specific fw_id to run in reservation mode', default=None, type=int)
     parser.add_argument('-w', '--fworker_file', help='path to fworker file', default=FWORKER_LOC)
     parser.add_argument('-q', '--queueadapter_file', help='path to queueadapter file',
                         default=QUEUEADAPTER_LOC)
     parser.add_argument('-c', '--config_dir',
                         help='path to a directory containing the config file (used if -l, -w, -q unspecified)',
                         default=CONFIG_FILE_DIR)
-    parser.add_argument('-f', '--fill_mode', help='launch queue submissions even when there is nothing to run',
+    parser.add_argument('-fm', '--fill_mode', help='launch queue submissions even when there is nothing to run',
                         action='store_true')
 
     rapid_parser.add_argument('-m', '--maxjobs_queue',
@@ -129,6 +128,9 @@ def qlaunch():
     rapid_parser.add_argument('--timeout', help='timeout (secs) after which to quit (default None)',
                               default=None, type=int)
     rapid_parser.add_argument('--sleep', help='sleep time between loops', default=None, type=int)
+    
+    single_parser.add_argument('-f', '--fw_id', help='specific fw_id to run in reservation mode', 
+                               default=None, type=int)
 
     args = parser.parse_args()
 

--- a/fireworks/scripts/qlaunch_run.py
+++ b/fireworks/scripts/qlaunch_run.py
@@ -107,6 +107,7 @@ def qlaunch():
     parser.add_argument('-s', '--silencer', help='shortcut to mute log messages', action='store_true')
     parser.add_argument('-r', '--reserve', help='reserve a fw', action='store_true')
     parser.add_argument('-l', '--launchpad_file', help='path to launchpad file', default=LAUNCHPAD_LOC)
+    parser.add_argument('-f', '--fw_id', help='specific fw_id to run in reservation mode', default=None, type=int)
     parser.add_argument('-w', '--fworker_file', help='path to fworker file', default=FWORKER_LOC)
     parser.add_argument('-q', '--queueadapter_file', help='path to queueadapter file',
                         default=QUEUEADAPTER_LOC)


### PR DESCRIPTION
* Adds qlaunching of specific fireworks, e. g. `qlaunch -r singleshot -f fw_id`
* Also added a few notes to priority_tutorial.rst about rlaunching and qlaunching specific fireworks.

Note that I changed the abbreviated flag for --fill_mode to -fm to avoid overlap with -f, which I thought should be the same for rlaunch and qlaunch.  They're part of separate parsers, so it's not strictly necessary, but might make things a little less confusing.