### PR TITLE
lpad webgui gives error when show report: OperationFailure: FieldPath field names may not contain '.'.

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -248,10 +248,13 @@ class LaunchPad(FWSerializable):
         while True:
             self.m_logger.info('Performing maintenance on Launchpad...')
             self.m_logger.debug('Tracking down FIZZLED jobs...')
-            fl, ff = self.detect_lostruns(fizzle=True)
+            fl, ff, inconsistent_fw_ids = self.detect_lostruns(fizzle=True)
             if fl:
                 self.m_logger.info('Detected {} FIZZLED launches: {}'.format(len(fl), fl))
                 self.m_logger.info('Detected {} FIZZLED FWs: {}'.format(len(ff), ff))
+            if inconsistent_fw_ids:
+                self.m_logger.info('Detected {} FIZZLED inconsistent fireworks: {}'.format(len(inconsistent_fw_ids),
+                                                                                           inconsistent_fw_ids))
 
             self.m_logger.debug('Tracking down stuck RESERVED jobs...')
             ur = self.detect_unreserved(rerun=True)

--- a/fireworks/features/fw_report.py
+++ b/fireworks/features/fw_report.py
@@ -73,7 +73,7 @@ class FWReport:
                                       "date_key": {"$substr": ["$"+time_field, 0, date_key_idx]}}})
         pipeline.append({"$group": {"_id": {"state:": "$state", "date_key": "$date_key"},
                                     "count": {"$sum": 1}, "state": {"$first": "$state"}}})
-        pipeline.append({"$group": {"_id": {"_id.date_key": "$_id.date_key"},
+        pipeline.append({"$group": {"_id": {"_id_date_key": "$_id.date_key"},
                                     "date_key": {"$first": "$_id.date_key"},
                                     "states": {"$push": {"count": "$count", "state": "$state"}}}})
         pipeline.append({"$sort": {"date_key": -1}})


### PR DESCRIPTION
Mongo Version:

```
db version v3.4.0
git version: f4240c60f005be757399042dc12f6addbc3170c1
OpenSSL version: OpenSSL 1.0.1e-fips 11 Feb 2013
allocator: tcmalloc
modules: none
build environment:
    distmod: rhel62
    distarch: x86_64
    target_arch: x86_64
```

Package list:
```
FireWorks==1.3.9
Flask==0.11.1
Jinja2==2.8
MarkupSafe==0.23
PyYAML==3.12
Werkzeug==0.11.11
click==6.6
flask-paginate==0.4.5
gunicorn==19.6.0
itsdangerous==0.24
monty==0.9.6
paramiko==2.1.0
pyasn1==0.1.9
pymongo==3.4.0
python-dateutil==2.6.0
six==1.10.0
tabulate==0.7.7
wsgiref==0.1.2
```
After started webgui, when click links in Summary Reports, page shows internal error, console log is below:

```
(firework)[root@ops fireworks]# lpad webgui --host=0.0.0.0
 * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
[2016-12-14 15:42:36,563] ERROR in app: Exception on /report/minutes/30/ [GET]
Traceback (most recent call last):
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/flask/app.py", line 1988, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/flask/app.py", line 1641, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/flask/app.py", line 1544, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/flask/app.py", line 1639, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/flask/app.py", line 1625, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/fireworks/flask_site/app.py", line 51, in decorated
    return f(*args, **kwargs)
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/fireworks/flask_site/app.py", line 276, in report
    additional_query=app.BASE_Q)
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/fireworks/features/fw_report.py", line 83, in get_stats
    for x in coll.aggregate(pipeline):
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/pymongo/collection.py", line 1870, in aggregate
    collation=collation)
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/pymongo/collection.py", line 232, in _command
    collation=collation)
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/pymongo/pool.py", line 419, in command
    collation=collation)
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/pymongo/network.py", line 116, in command
    parse_write_concern_error=parse_write_concern_error)
  File "/home/shenjh/envs/firework/lib/python2.7/site-packages/pymongo/helpers.py", line 210, in _check_command_response
    raise OperationFailure(msg % errmsg, code, response)
OperationFailure: FieldPath field names may not contain '.'.
```
This pull request fixes the error, tests ok on current latest 1.3.9.