### PR TITLE
Ensure encoding of UTF-8 before parsing command output

### DIFF
--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -70,9 +70,8 @@ class CommonAdapter(QueueAdapterBase):
 
     def _parse_jobid(self, output_str):
         if self.q_type == "SLURM":
-            if sys.version_info[0] > 2:
-                if isinstance(output_str, bytes):
-                    output_str = output_str.decode('utf-8')
+            # For Py3 compatibility, ensure output_str is not a byte string
+            output_str = output_str.decode('utf-8')
             for l in output_str.split("\n"):
                 if l.startswith("Submitted batch job"):
                     return int(l.split()[-1])


### PR DESCRIPTION
It is strange that stdout from SLURM submission command is a raw bytes string. Anyway, I got a raw byte string in a Python3 environment. Now the code checks the type of "output_str" variable, if it is really a raw bytes string, convert it to UTF-8 str explicitly. Otherwise, the split() function will raise an error.