### PR TITLE
Added qlauncher option for remote shell.

### DIFF
--- a/fireworks/scripts/qlaunch_run.py
+++ b/fireworks/scripts/qlaunch_run.py
@@ -90,6 +90,9 @@ def qlaunch():
                         help="Password for remote host (if necessary). For "
                              "best operation, it is recommended that you do "
                              "passwordless ssh.")
+    parser.add_argument("-rsh", "--remote_shell",
+                        help="Shell command to use on remote host for running submission.",
+                        default='/bin/bash -l -c')
 
     parser.add_argument("-rs", "--remote_setup",
                         help="Setup the remote config dir using files in "
@@ -184,7 +187,7 @@ def qlaunch():
         if args.remote_host:
             for h in args.remote_host:
                 with settings(host_string=h, user=args.remote_user,
-                              password=args.remote_password):
+                              password=args.remote_password, shell=args.remote_shell):
                     for r in args.remote_config_dir:
                         r = os.path.expanduser(r)
                         with cd(r):


### PR DESCRIPTION
For at least one cluster I've encountered (PSC Bridges), the [default shell used by fabric](http://docs.fabfile.org/en/1.13/usage/env.html#shell) was not initializing with the configuration files I expected to give the proper environment for my qlauncher. This PR adds an option to the qlauncher for passing in the shell command that fabric will use.