### PR TITLE
add gres support to  SLURM_template.txt

### DIFF
--- a/fireworks/user_objects/queue_adapters/SLURM_template.txt
+++ b/fireworks/user_objects/queue_adapters/SLURM_template.txt
@@ -4,6 +4,7 @@
 #SBATCH --ntasks=$${ntasks}
 #SBATCH --ntasks-per-node=$${ntasks_per_node}
 #SBATCH --cpus-per-task=$${cpus_per_task}
+#SBATCH --gres=$${gres}
 #SBATCH --qos=$${qos}
 #SBATCH --time=$${walltime}
 #SBATCH --partition=$${queue}


### PR DESCRIPTION
add Specifies a comma delimited list of generic consumable resources to SLURM_template.txt, to support manage the occupation of GPU.