### PR TITLE
Enable optional queue setting in SGE queue adapter

### DIFF
--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -115,7 +115,7 @@ class CommonAdapter(QueueAdapterBase):
         elif self.q_type == 'SGE':
             status_cmd.extend(['-u', username])
             if 'queue' in self and self['queue']:
-                status_cmd.extend(['-p', self['queue']])
+                status_cmd.extend(['-q', self['queue']])
         else:
             status_cmd.extend(['-u', username])
 

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -113,7 +113,9 @@ class CommonAdapter(QueueAdapterBase):
             header="JobId:User:Queue:Jobname:Nodes:Procs:Mode:WallTime:State:RunTime:Project:Location"
             status_cmd.extend(['--header', header, '-u', username])
         elif self.q_type == 'SGE':
-            status_cmd.extend(['-q', self['queue'], '-u', username])
+            status_cmd.extend(['-u', username])
+            if 'queue' in self and self['queue']:
+                status_cmd.extend(['-p', self['queue']])
         else:
             status_cmd.extend(['-u', username])
 


### PR DESCRIPTION
Currently the SGE queue adapter requires the queue parameter to be set. This causes an issue for clusters where SGE is configured such that jobs are assigned a queue at run time, as it means the number of queuing jobs cannot be determined.

For these systems it is OK if the queue parameter is not set, therefore I have made this an optional parameter (similar to how it is handled in the SLURM section of the code).