### PR TITLE
Added check in Workflow.rerun_fw to only rerun child if not waiting

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -874,7 +874,8 @@ class Workflow(FWSerializable):
 
         # re-run all the children
         for child_id in self.links[fw_id]:
-            updated_ids = updated_ids.union(self.rerun_fw(child_id, updated_ids))
+            if self.id_fw[child_id].state != 'WAITING':
+                updated_ids = updated_ids.union(self.rerun_fw(child_id, updated_ids))
 
         # refresh the WF to get the states updated
         return self.refresh(fw_id, updated_ids)


### PR DESCRIPTION
In `Workflow.rerun_fw`, when you rerun a Firework, it will recursively go down and rerun all children, then children of that child etc:
https://github.com/materialsproject/fireworks/blob/9b26bb7037a12fcdcb8db17fb3fde9cdd7233686/fireworks/core/firework.py#L858-L880


For a fork/branch pattern (like below) this will scale badly as rerunning the `FIZZLED` FW at the top then reruns `FW1`, then `FW4`, then `FW5-7`, then `FW8`, but then it will rerun `FW2`, `FW4`, `FW5-7` again etc.  If you add another fork/branch below it will scale O(n^3, 4, 5), etc as you add more fork/branches.  I'm running a genetic algorithm, so I have ~60 fork/branches, so rerunning a FW using the launchpad just times out.

I've changed `rerun_fw` to only rerun children if the child was not `WAITING`.  This will assume that underneath WAITING FWs there's not any other "ACTIVE" FWs, is this a safe assumption?

```
  FIZZLED
     +
+---------+
|    |    |
v    v    v
FW1  FW2  FW3
+    +    +
+---------+
     v
     FW4
     +
+---------+
|    |    |
v    v    v
FW5  FW6  FW7
+    +    +
+---------+
     v
     FW8

```