### PR TITLE
Performance for LaunchPad.add_wf

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -1261,8 +1261,8 @@ class LaunchPad(FWSerializable):
         # sort the FWs by id, then the new FW_ids will match the order of the old ones...
         fws.sort(key=lambda x: x.fw_id)
 
-        used_ids = []
         if reassign_all:
+            used_ids = []
             # we can request multiple fw_ids up front
             # this is the FIRST fw_id we should use
             first_new_id = self.get_new_fw_id(quantity=len(fws))
@@ -1280,7 +1280,6 @@ class LaunchPad(FWSerializable):
                     new_id = self.get_new_fw_id()
                     old_new[fw.fw_id] = new_id
                     fw.fw_id = new_id
-                    used_ids.append(new_id)
 
                 self.fireworks.find_one_and_replace({'fw_id': fw.fw_id},
                                                     fw.to_db_dict(),


### PR DESCRIPTION
I was getting annoyed with submitting a ~50,000 firework Workflow was, so I made a few changes which seem to work for me, but maybe there's something obvious I missed.

 - Added optional quantity kwarg to `LaunchPad.get_new_fw_id` (allows multiple fw_ids to be taken at once)
 - `LaunchPad._upsert_fws` with `reassign_all = True` now does fewer database transactions (3 in total, rather than N)
