### PR TITLE
Rewrote Workflow.Links to maintain parent_links rather than build on demand

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -708,6 +708,7 @@ class Workflow(FWSerializable):
         name = name or 'unnamed WF'  # prevent None names
 
         links_dict = links_dict if links_dict else {}
+        self.links = Workflow.Links(links_dict)
 
         # main dict containing mapping of an id to a Firework object
         self.id_fw = {}
@@ -716,10 +717,8 @@ class Workflow(FWSerializable):
                 raise ValueError('FW ids must be unique!')
             self.id_fw[fw.fw_id] = fw
 
-            if fw.fw_id not in links_dict and fw not in links_dict:
-                links_dict[fw.fw_id] = []
-
-        self.links = Workflow.Links(links_dict)
+            if fw.fw_id not in self.links:
+                self.links[fw.fw_id] = []
 
         # add depends on
         for fw in fireworks:

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -624,7 +624,23 @@ class Workflow(FWSerializable):
             for child in val:
                 self._parent_links.setdefault(child, []).append(key)
             # Finally add to "real" dict
-            super(Workflow.Links, self).__setitem__(int(key), val)
+            super(Workflow.Links, self).__setitem__(key, val)
+
+        def __delitem__(self, key):
+            key = int(key)
+            # must delete reverse key
+            vals = self[key]
+            for val in vals:
+                parents = self._parent_links[val]
+                parents.remove(key)
+                if not parents:
+                    # if there are no more parents, remove the entry entirely
+                    del self._parent_links[val]
+                else:
+                    # else set to the now reduced list
+                    self._parent_links[val] = parents
+
+            super(Workflow.Links, self).__delitem__(key)
 
         @property
         def nodes(self):

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -1639,6 +1639,8 @@ class LazyFirework(object):
         self._launches = {k: False for k in self.db_launch_fields}
         self._fw, self._lids, self._state = None, None, None
 
+    def __int__(self):
+        return self.fw_id
     # FireWork methods
 
     # Treat state as special case as it is always required when accessing a Firework lazily

--- a/fireworks/tests/multiprocessing_tests.py
+++ b/fireworks/tests/multiprocessing_tests.py
@@ -21,14 +21,6 @@ TESTDB_NAME = 'job_packing_unittest'
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-class TestLinks(TestCase):
-    def test_pickle(self):
-        links1 = Workflow.Links({1: 2, 3: [5, 7, 8]})
-        s = pickle.dumps(links1)
-        links2 = pickle.loads(s)
-        self.assertEqual(str(links1), str(links2))
-
-
 class TestCheckoutFW(TestCase):
     lp = None
 

--- a/fireworks/tests/test_links.py
+++ b/fireworks/tests/test_links.py
@@ -1,12 +1,67 @@
 from unittest import TestCase
 import pickle
 
-from fireworks import Workflow
+from fireworks import Firework, Workflow
 
 
 class TestLinks(TestCase):
+    def setUp(self):
+        self.links = Workflow.Links({1: 2, 3: [5, 7, 8], 4: 5})
+
     def test_pickle(self):
-        links1 = Workflow.Links({1: 2, 3: [5, 7, 8]})
-        s = pickle.dumps(links1)
+        s = pickle.dumps(self.links)
         links2 = pickle.loads(s)
-        self.assertEqual(str(links1), str(links2))
+        self.assertEqual(str(self.links), str(links2))
+
+    def test_nodes(self):
+        self.assertEqual(self.links.nodes, [1, 2, 3, 4, 5, 7, 8])
+
+    def test_parent_links(self):
+        self.assertEqual(self.links.parent_links,
+                         {2: [1], 5: [3, 4], 7: [3], 8: [3]})
+
+    def test_firework_keys(self):
+        # test setting with Fireworks as keys still works
+        fw1 = Firework([], fw_id=1)
+        l = Workflow.Links({fw1: 2, 3: [5, 7, 8]})
+        self.assertEqual(1 in l.keys(), True)
+
+    def test_firework_values(self):
+        # test setting with Fireworks amongst values
+        fw3 = Firework([], fw_id=3)
+        fw4 = Firework([], fw_id=4)
+        l = Workflow.Links({1: 2,  6: [fw3, fw4, 5]})
+
+        self.assertEqual(l[6], [3, 4, 5])
+
+    def test_to_dict(self):
+        self.assertEqual(self.links.to_dict(),
+                         {'1': [2],
+                          '3': [5, 7, 8],
+                          '4': [5]})
+
+    def test_to_db_dict(self):
+        self.assertEqual(self.links.to_db_dict(),
+                         {'links': {'1': [2], '3': [5, 7, 8], '4': [5]},
+                          'nodes': [1, 2, 3, 4, 5, 7, 8],
+                          'parent_links': {'2': [1], '5': [3, 4], '7': [3],
+                                           '8': [3]}})
+
+    def test_from_dict(self):
+        l = Workflow.Links.from_dict({1: [5, 6]})
+        self.assertEqual(l, Workflow.Links({1: [5, 6]}))
+
+    def test_getitem(self):
+        self.assertEqual(self.links[1], [2])
+        self.assertEqual(self.links[3], [5, 7, 8])
+        self.assertEqual(self.links[4], [5])
+
+    def test_delitems(self):
+        del self.links[4]
+        self.assertEqual(self.links.nodes, [1, 2, 3, 5, 7, 8])
+
+    def test_items(self):
+        self.assertEqual(list(self.links.items()),
+                         [(1, [2]),
+                          (3, [5, 7, 8]),
+                          (4, [5])])

--- a/fireworks/tests/test_links.py
+++ b/fireworks/tests/test_links.py
@@ -60,6 +60,13 @@ class TestLinks(TestCase):
         del self.links[4]
         self.assertEqual(self.links.nodes, [1, 2, 3, 5, 7, 8])
 
+    def test_delitems_parents(self):
+        # check that parent_links get updated when other entries are deleted
+        del self.links[4]
+
+        self.assertEqual(self.links.parent_links,
+                         {2: [1], 5: [3], 7: [3], 8: [3]})
+
     def test_items(self):
         self.assertEqual(list(self.links.items()),
                          [(1, [2]),

--- a/fireworks/tests/test_links.py
+++ b/fireworks/tests/test_links.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+import pickle
+
+from fireworks import Workflow
+
+
+class TestLinks(TestCase):
+    def test_pickle(self):
+        links1 = Workflow.Links({1: 2, 3: [5, 7, 8]})
+        s = pickle.dumps(links1)
+        links2 = pickle.loads(s)
+        self.assertEqual(str(links1), str(links2))


### PR DESCRIPTION
This improves performance a little bit, as building the `parent_links` dict is slower with large Workflows.

The API of the Links object should be identical to before.

There was a weird bug in `Workflow.__init__` where when creating the WF from the database, the keys in `links_dict` were all strings, so the check "`if fw.fw_id not in links_dict and fw not in links_dict:`" would always think that the FW wasn't in the links_dict (because it was a string) so you'd end up with a empty list for all FWs, (as well as the key-as-string entry), which would later get ironed out in `Links.__init__`.  This is why the usage of Links is slightly changed there.