### PR TITLE
Recovery fix

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -1332,7 +1332,7 @@ class LaunchPad(FWSerializable):
             
         # If no launch recovery specified, unset the firework recovery spec
         else:
-            set_spec = {"$unset":{"spec._recover_launch":""}}
+            set_spec = {"$unset":{"spec._recovery":""}}
             self.fireworks.find_one_and_update({"fw_id":fw_id}, set_spec)
 
 

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -901,6 +901,10 @@ class LaunchPadRerunExceptionTest(unittest.TestCase):
         self.assertEqual(ExecutionCounterTask.exec_counter, 1)
         self.assertEqual(ExceptionTestTask.exec_counter, 2)
         self.assertFalse(os.path.exists(os.path.join(dirs[1], "date_file")))
+        # Ensure rerun deletes recovery by default
+        self.lp.rerun_fw(1)
+        fw = self.lp.get_fw_by_id(1)
+        self.assertFalse("_recovery" in fw.spec) 
 
     def test_task_level_rerun_cp(self):
         rapidfire(self.lp, self.fworker, m_dir=MODULE_DIR)


### PR DESCRIPTION
Task-level recovery has a bug in that LaunchPad.rerun_fws unsets the wrong spec key on a normal rerun.  This PR should fix.  Might want to wait on tests, something was a bit weird on my circle tests, but I think it's a config issue on my fork.