### PR TITLE
correction for errors when handling multiple qadapters on a single LS…

### DIFF
--- a/fireworks/scripts/qlaunch_run.py
+++ b/fireworks/scripts/qlaunch_run.py
@@ -41,7 +41,7 @@ def do_launch(args):
     if not args.queueadapter_file and os.path.exists(
             os.path.join(args.config_dir, 'my_qadapter.yaml')):
         args.queueadapter_file = os.path.join(args.config_dir, 'my_qadapter.yaml')
-    else:
+    elif not args.queueadapter_file:
         args.queueadapter_file = QUEUEADAPTER_LOC
 
     launchpad = LaunchPad.from_file(

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -139,8 +139,12 @@ class CommonAdapter(QueueAdapterBase):
                 # last line is: "1 job step(s) in query, 0 waiting, ..."
                 return int(output_str.split('\n')[-2].split()[0])
         if self.q_type == "LoadSharingFacility":
-            #Just count the number of lines
-            return len(output_str.split('\n'))
+            # Count the number of lines which pertian to the queue
+            cnt = 0
+            for line in output_str.split('\n'):
+                if line.endswith(self['queue']):
+                    cnt += 1
+            return cnt
         if self.q_type == "SGE":
             # want only lines that include username;
             # this will exclude e.g. header lines


### PR DESCRIPTION
…F cluster

When running multiple queue adapters on a single LSF cluster, the maximum queue count for each rapidfire run used to refer to the total number of submitted jobs. This is a potential problem for automation since not all queues completed jobs at the same rate or are equally available. After a while, the queues which complete jobs faster will deplete their supply of queued jobs which will steadily be replaced by queue submissions to the slower queues. Eventually, submissions to the slowest queue will beat the others out.

This is a fix for LSF systems which identifies the number of jobs submitted to a specific queue. That way, submission can be managed across all queues correctly.