### PR TITLE
Print help if no command supplied to lpad

### DIFF
--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -1046,7 +1046,11 @@ def lpad():
 
     args.output = get_output_func(args.output)
 
-    args.func(args)
+    if args.command is None:
+        # if no command supplied, print help
+        parser.print_help()
+    else:
+        args.func(args)
 
 if __name__ == '__main__':
     lpad()


### PR DESCRIPTION
Previously would just return a slightly cryptic error.