### PR TITLE
Remove hard-coded secret key

### DIFF
--- a/fireworks/flask_site/app.py
+++ b/fireworks/flask_site/app.py
@@ -19,7 +19,7 @@ app = Flask(__name__)
 app.use_reloader = True
 app.secret_key = os.environ.get(
     "FWAPP_SECRET_KEY",
-    '0\x07)\x95\x96)\xb9\xdf1\xc0l4\x99\xc4\xf1\x88Jk\xb4lZ\xb2\x81X')
+    os.urandom(24))
 
 hello = __name__
 lp = LaunchPad.from_dict(json.loads(os.environ["FWDB_CONFIG"]))


### PR DESCRIPTION
I don't think it matters too much right now, but we should probably avoid hard-coding a secret key in a public repo? I think this is mostly used for session cookies and the like.