### PR TITLE
new sub-commands to lpad

### DIFF
--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -165,6 +165,21 @@ def add_wf(args):
         lp.add_wf(fwf)
 
 
+def append_wf(args):
+    lp = get_lp(args)
+    lp.append_wf(
+        Workflow.from_file(args.wf_file),
+        args.fw_id,
+        detour=args.detour,
+        pull_spec_mods=args.pull_spec_mods
+    )
+
+
+def dump_wf(args):
+    lp = get_lp(args)
+    lp.get_wf_by_fw_id(args.fw_id).to_file(args.wf_file)
+
+
 def add_wf_dir(args):
     lp = get_lp(args)
     for filename in os.listdir(args.wf_dir):
@@ -685,6 +700,18 @@ def lpad():
     addwf_parser.add_argument('wf_file', nargs="+",
                               help="Path to a Firework or Workflow file")
     addwf_parser.set_defaults(func=add_wf)
+
+    append_wf_parser = subparsers.add_parser('append_wflow', help='append a workflow from file to a workflow on launchpad')
+    append_wf_parser.add_argument('-i', '--fw_id', type=int, nargs='+', help='parent firework ids')
+    append_wf_parser.add_argument('-f', '--wf_file', help='path to a firework or workflow file')
+    append_wf_parser.add_argument('-d', '--detour', help='append workflow as a detour', dest='detour', action='store_true')
+    append_wf_parser.add_argument('--no_pull_spec_mods', help='do not to pull spec_mods from parent', dest='pull_spec_mods', action='store_false')
+    append_wf_parser.set_defaults(func=append_wf, detour=False, pull_spec_mods=True)
+
+    dump_wf_parser = subparsers.add_parser('dump_wflow', help='dump a workflow from launchpad to a file')
+    dump_wf_parser.add_argument('-i', '--fw_id', type=int, help='the id of a firework from the workflow')
+    dump_wf_parser.add_argument('-f', '--wf_file', help='path to a local file to store the workflow')
+    dump_wf_parser.set_defaults(func=dump_wf)
 
     addscript_parser = subparsers.add_parser('add_scripts', help='quickly add a script '
                                                                  '(or several scripts) to run in sequence')

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -705,7 +705,7 @@ def lpad():
     append_wf_parser.add_argument('-i', '--fw_id', type=int, nargs='+', help='parent firework ids')
     append_wf_parser.add_argument('-f', '--wf_file', help='path to a firework or workflow file')
     append_wf_parser.add_argument('-d', '--detour', help='append workflow as a detour', dest='detour', action='store_true')
-    append_wf_parser.add_argument('--no_pull_spec_mods', help='do not to pull spec_mods from parent', dest='pull_spec_mods', action='store_false')
+    append_wf_parser.add_argument('--no_pull_spec_mods', help='do not to pull spec mods from parent', dest='pull_spec_mods', action='store_false')
     append_wf_parser.set_defaults(func=append_wf, detour=False, pull_spec_mods=True)
 
     dump_wf_parser = subparsers.add_parser('dump_wflow', help='dump a workflow from launchpad to a file')

--- a/fireworks/tests/cmd_line_test.sh
+++ b/fireworks/tests/cmd_line_test.sh
@@ -18,3 +18,8 @@ do
     test_cmd lpad get_fws -d $mode
 done
 rlaunch singleshot
+
+test_cmd lpad append_wflow -i 1 -f fw_tutorials/firetask/fw_adder.yaml
+test_cmd lpad dump_wflow -i 1 -f test_dump_wflow.json && rm -f test_dump_wflow.json
+test_cmd rlaunch singleshot
+test_cmd lpad delete_wflows -i 1


### PR DESCRIPTION
Very often we need to extend existing workflows and for that we initially used the python interface to the method `fireworks.core.firework.Workflow.append_wf` via a three-line separate python script. Much more convenient would be to use the `lpad` command for this rather general operation. In addition, often a workflow has to be dumped from the LaunchPad for editing or sharing. For these operations, two new sub-commands in the `lpad` command are suggested: `append_wflow` and `dump_wflow`. The added `lpad` help strings document the usage of the new commands and also the tests in `cmd_line_test.sh` are extended accordingly.