### PR TITLE
flask_site: Remove unnecessary, performance-impacting script fetch

### DIFF
--- a/fireworks/flask_site/templates/base.html
+++ b/fireworks/flask_site/templates/base.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
 <html lang="en">
 <head>
-    <script>document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>')</script>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/bootstrap.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/flat-ui.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/styles.css') }}">
@@ -20,8 +19,8 @@
     <div class="container">
         {% block content %}{% endblock %}
     </div>
-    
-    
+
+
     {% block footer %}
     <hr>
     <footer class="footer container text-center">


### PR DESCRIPTION
The fetched script (livereload.js) depends on a running LiveReload server, which is used only for development and can impact deployments (a server may not quickly 404 the file in part because the request is to a non-standard port, so the page may take tens of seconds to load).