### PR TITLE
Bulk insert add wfs

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -315,7 +315,7 @@ class LaunchPad(FWSerializable):
         self.m_logger.info('Added a workflow. id_map: {}'.format(old_new))
         return old_new
 
-    def add_wfs(self, wfs):
+    def bulk_add_wfs(self, wfs):
         """
         Adds a list of workflows to the fireworks database
         using insert_many for both the fws and wfs, is
@@ -351,9 +351,9 @@ class LaunchPad(FWSerializable):
 
         # Insert all fws and wfs, do workflows first so fws don't
         # get checked out prematurely
-        self.workflows.insert_many([wf.to_db_dict() for wf in wfs])
-        all_fws = chain.from_iterable([wf.fws for wf in wfs])
-        self.fireworks.insert_many([fw.to_db_dict() for fw in all_fws])
+        self.workflows.insert_many(wf.to_db_dict() for wf in wfs)
+        all_fws = chain.from_iterable(wf.fws for wf in wfs)
+        self.fireworks.insert_many(fw.to_db_dict() for fw in all_fws)
         return None
 
     def append_wf(self, new_wf, fw_ids, detour=False, pull_spec_mods=True):
@@ -1370,7 +1370,7 @@ class LaunchPad(FWSerializable):
             set_spec = {'$set': {'spec._recovery': recovery}}
             if recover_mode == 'prev_dir':
                 prev_dir = self.get_launch_by_id(recovery.get('_launch_id')).launch_dir
-                set_spec['$set']['spec._launch_dir'] = prev_dir 
+                set_spec['$set']['spec._launch_dir'] = prev_dir
             self.fireworks.find_one_and_update({"fw_id": fw_id}, set_spec)
 
         # If no launch recovery specified, unset the firework recovery spec
@@ -1583,7 +1583,7 @@ class LaunchPad(FWSerializable):
                                                             })
                     if f:
                         self._refresh_wf(fw_id)
-                
+
                 if 'checkpoint' in offline_data:
                     m_launch.touch_history(checkpoint=offline_data['checkpoint'])
                     self.launches.find_one_and_replace({'launch_id': m_launch.launch_id},

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -55,7 +55,8 @@ class LaunchPadTest(unittest.TestCase):
 
 
     def tearDown(self):
-        self.lp.reset(password=None,require_password=False)
+        self.lp.reset(password=None, require_password=False,
+                      max_reset_wo_password=1000)
         # Delete launch locations
         if os.path.exists(os.path.join('FW.json')):
             os.remove('FW.json')
@@ -117,18 +118,19 @@ class LaunchPadTest(unittest.TestCase):
     def test_add_wfs(self):
         ftask = ScriptTask.from_str('echo "lorem ipsum"')
         wfs = []
-        for n in range(100):
-            # create workflows with 3-10 simple fireworks
-            wfs.append(Workflow([Firework(ftask, name='lorem')
-                                 for n in range(0, randint(3, 10))],
-                                name='lorem workflow'))
-        self.lp.add_wfs(wfs)
+        for n in range(50):
+            # Add two workflows with 3 and 5 simple fireworks
+            wf3 = Workflow([Firework(ftask, name='lorem') for _ in range(3)],
+                           name='lorem wf')
+            wf5 = Workflow([Firework(ftask, name='lorem') for _ in range(5)],
+                           name='lorem wf')
+            wfs.extend([wf3, wf5])
+        self.lp.bulk_add_wfs(wfs)
         num_fws_total = sum([len(wf.fws) for wf in wfs])
         distinct_fw_ids = self.lp.fireworks.distinct('fw_id', {'name': 'lorem'})
         self.assertEqual(len(distinct_fw_ids), num_fws_total)
-        num_wfs_in_db = len(self.lp.get_wf_ids({"name": "lorem workflow"}))
+        num_wfs_in_db = len(self.lp.get_wf_ids({"name": "lorem wf"}))
         self.assertEqual(num_wfs_in_db, len(wfs))
-        self.lp.reset('', require_password=False, max_reset_wo_password=1000)
 
 
 class LaunchPadDefuseReigniteRerunArchiveDeleteTest(unittest.TestCase):

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -17,6 +17,7 @@ import shutil
 import datetime
 from multiprocessing import Process
 import filecmp
+from random import randint
 
 from fireworks import Firework, Workflow, LaunchPad, FWorker
 from fireworks.core.rocket_launcher import rapidfire, launch_rocket
@@ -115,7 +116,6 @@ class LaunchPadTest(unittest.TestCase):
 
     def test_add_wfs(self):
         ftask = ScriptTask.from_str('echo "lorem ipsum"')
-        from random import randint
         wfs = []
         for n in range(100):
             # create workflows with 3-10 simple fireworks
@@ -129,8 +129,6 @@ class LaunchPadTest(unittest.TestCase):
         num_wfs_in_db = len(self.lp.get_wf_ids({"name": "lorem workflow"}))
         self.assertEqual(num_wfs_in_db, len(wfs))
         self.lp.reset('', require_password=False, max_reset_wo_password=1000)
-
-
 
 
 class LaunchPadDefuseReigniteRerunArchiveDeleteTest(unittest.TestCase):

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -113,6 +113,25 @@ class LaunchPadTest(unittest.TestCase):
         self.assertEqual(len(fw_ids), 3)
         self.lp.reset('',require_password=False)
 
+    def test_add_wfs(self):
+        ftask = ScriptTask.from_str('echo "lorem ipsum"')
+        from random import randint
+        wfs = []
+        for n in range(100):
+            # create workflows with 3-10 simple fireworks
+            wfs.append(Workflow([Firework(ftask, name='lorem')
+                                 for n in range(0, randint(3, 10))],
+                                name='lorem workflow'))
+        self.lp.add_wfs(wfs)
+        num_fws_total = sum([len(wf.fws) for wf in wfs])
+        distinct_fw_ids = self.lp.fireworks.distinct('fw_id', {'name': 'lorem'})
+        self.assertEqual(len(distinct_fw_ids), num_fws_total)
+        num_wfs_in_db = len(self.lp.get_wf_ids({"name": "lorem workflow"}))
+        self.assertEqual(num_wfs_in_db, len(wfs))
+        self.lp.reset('', require_password=False, max_reset_wo_password=1000)
+
+
+
 
 class LaunchPadDefuseReigniteRerunArchiveDeleteTest(unittest.TestCase):
 

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -17,7 +17,6 @@ import shutil
 import datetime
 from multiprocessing import Process
 import filecmp
-from random import randint
 
 from fireworks import Firework, Workflow, LaunchPad, FWorker
 from fireworks.core.rocket_launcher import rapidfire, launch_rocket
@@ -118,7 +117,7 @@ class LaunchPadTest(unittest.TestCase):
     def test_add_wfs(self):
         ftask = ScriptTask.from_str('echo "lorem ipsum"')
         wfs = []
-        for n in range(50):
+        for _ in range(50):
             # Add two workflows with 3 and 5 simple fireworks
             wf3 = Workflow([Firework(ftask, name='lorem') for _ in range(3)],
                            name='lorem wf')


### PR DESCRIPTION
I've found myself in need of a more efficient method of workflow addition to the launchpad lately (e. g. for adding thousands of workflows at a time), so I wrote a method that does it a bit more efficiently using some of mongo's bulk insertion functionality.

I'm not really sure if this is a good idea for the master branch (it seems less secure than adding them one at a time), but I figured I'd submit this PR to see if there was any feedback on how it might be adapted for general use (or if there's a better strategy), if there are any issues.

Also included rudimentary unit test.