### PR TITLE
Add support for pickle/unpickle of Firetasks

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -43,11 +43,7 @@ __email__ = "ajain@lbl.gov"
 __date__ = "Feb 5, 2013"
 
 
-class FiretaskMeta(abc.ABCMeta):
-    pass
-
-
-@add_metaclass(FiretaskMeta)
+@add_metaclass(abc.ABCMeta)
 class FiretaskBase(defaultdict, FWSerializable):
     """
     FiretaskBase is used like an abstract class that defines a computing task

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -44,12 +44,7 @@ __date__ = "Feb 5, 2013"
 
 
 class FiretaskMeta(abc.ABCMeta):
-    def __call__(cls, *args, **kwargs):
-        o = abc.ABCMeta.__call__(cls, *args, **kwargs)
-        for k in cls.required_params:
-            if k not in o:
-                raise ValueError("{}: Required parameter {} not specified!".format(cls, k))
-        return o
+    pass
 
 
 @add_metaclass(FiretaskMeta)
@@ -65,6 +60,10 @@ class FiretaskBase(defaultdict, FWSerializable):
 
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)
+
+        for k in self.required_params:
+            if k not in self:
+                raise ValueError("{}: Required parameter {} not specified!".format(self, k))
 
     @abc.abstractmethod
     def run_task(self, fw_spec):
@@ -102,6 +101,19 @@ class FiretaskBase(defaultdict, FWSerializable):
 
     def __repr__(self):
         return '<{}>:{}'.format(self.fw_name, dict(self))
+
+    # not strictly needed here for pickle/unpickle, but complements __setstate__
+    def __getstate__(self):
+        return self.to_dict()
+
+    # added to support pickle/unpickle
+    def __setstate__(self, state):
+        self.__init__(state)
+
+    # added to support pickle/unpickle
+    def __reduce__(self):
+        t = defaultdict.__reduce__(self)
+        return (t[0], (self.to_dict(),), t[2], t[3], t[4])
 
 
 class FWAction(FWSerializable):

--- a/fireworks/core/tests/test_firework.py
+++ b/fireworks/core/tests/test_firework.py
@@ -31,7 +31,8 @@ class FiretaskBaseTest(unittest.TestCase):
             def run_task(self, fw_spec):
                 return self["hello"]
 
-        self.assertRaises(ValueError, DummyTask)
+        with self.assertRaises(ValueError):
+            DummyTask()
         d = DummyTask(hello="world")
         self.assertEqual(d.run_task({}), "world")
         d = DummyTask({"hello": "world2"})
@@ -43,6 +44,30 @@ class FiretaskBaseTest(unittest.TestCase):
 
         d = DummyTask2()
         self.assertRaises(NotImplementedError, d.run_task, {})
+
+
+class PickleTask(FiretaskBase):
+    required_params = ["test"]
+
+    def run_task(self, fw_spec):
+        return self["test"]
+
+
+class FiretaskPickleTest(unittest.TestCase):
+    def setUp(self):
+        import pickle
+        self.task = PickleTask(test=0)
+        self.pkl_task = pickle.dumps(self.task)
+        self.upkl_task = pickle.loads(self.pkl_task)
+
+    def test_init(self):
+        self.assertIsInstance(self.upkl_task, PickleTask)
+        self.assertEqual(PickleTask.from_dict(self.task.to_dict()), self.upkl_task)
+        self.assertEqual(dir(self.task), dir(self.upkl_task))
+
+        result_task = self.task.run_task({})
+        result_upkl_task = self.upkl_task.run_task({})
+        self.assertEqual(result_task, result_upkl_task)
 
 
 @explicit_serialize


### PR DESCRIPTION
- Removes FiretaskMeta.\_\_call__, moves required parameter checks to FiretaskBase.\_\_init__
- Adds \_\_getstate__, \_\_setstate__, \_\_reduce__" to FiretaskBase
- Adds basic unit tests for pickle/unpickle to fireworks/core/tests/test_firework.py
- Small adjustment to one assert check in FiretaskBaseTest, since \_\_call__ was removed

The current behavior before this update throws a ValueError during unpickle because of how unpickle rebuilds the object, executing the metaclass \_\_call__ method with no arguments.

Originally, I had a workaround in FiretaskMeta that checked whether the inputs to \_\_call__ were length zero, and if so then bypass checking the required parameters.  This approach didn't cover all cases where you want to enforce required parameters, for example, ScriptTask().

Ultimately, it was more beneficial to move the parameter checks to FiretaskBase.\_\_init__, and then include a small number of magic methods to ensure pickling/unpickling could operate normally.

This *does* cause a small behavior change due to the removal of \_\_call__.  You can still instantiate a Firetask with the same syntax e.g., "cls()", you just no longer invoke metaclass.\_\_call__.