### PR TITLE
Option to delete launch dirs when deleting workflows

### DIFF
--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -402,7 +402,13 @@ class LaunchPadDefuseReigniteRerunArchiveDeleteTest(unittest.TestCase):
 
     def test_delete_wf(self):
         # Run a firework before deleting Zeus
-        launch_rocket(self.lp, self.fworker)
+        rapidfire(self.lp, self.fworker, nlaunches=1)
+
+        # Get the launch dir
+        fw = self.lp.get_fw_by_id(self.lp.get_fw_ids({'state':'COMPLETED'})[0])
+        launches = fw.launches
+        first_ldir = launches[0].launch_dir
+        self.assertTrue(os.path.isdir(first_ldir))
 
         # Delete workflow containing Zeus.
         self.lp.delete_wf(self.zeus_fw_id)
@@ -413,6 +419,30 @@ class LaunchPadDefuseReigniteRerunArchiveDeleteTest(unittest.TestCase):
         self.assertFalse(fw_ids)
         wf_ids = self.lp.get_wf_ids()
         self.assertFalse(wf_ids)
+        # Check that the launch dir has not been deleted
+        self.assertTrue(os.path.isdir(first_ldir))
+
+    def test_delete_wf_and_files(self):
+        # Run a firework before deleting Zeus
+        rapidfire(self.lp, self.fworker, nlaunches=1)
+
+        # Get the launch dir
+        fw = self.lp.get_fw_by_id(self.lp.get_fw_ids({'state':'COMPLETED'})[0])
+        launches = fw.launches
+        first_ldir = launches[0].launch_dir
+        self.assertTrue(os.path.isdir(first_ldir))
+
+        # Delete workflow containing Zeus.
+        self.lp.delete_wf(self.zeus_fw_id, delete_ldirs=True)
+        # Check if any fireworks and the workflow are available
+        with self.assertRaises(ValueError):
+            self.lp.get_wf_by_fw_id(self.zeus_fw_id)
+        fw_ids = self.lp.get_fw_ids()
+        self.assertFalse(fw_ids)
+        wf_ids = self.lp.get_wf_ids()
+        self.assertFalse(wf_ids)
+        # Check that the launch dir has not been deleted
+        self.assertFalse(os.path.isdir(first_ldir))
 
     def test_rerun_fws2(self):
         # Launch all fireworks

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -321,7 +321,7 @@ def delete_wfs(args):
     lp = get_lp(args)
     fw_ids = parse_helper(lp, args, wf_mode=True)
     for f in fw_ids:
-        lp.delete_wf(f)
+        lp.delete_wf(f, delete_ldirs=args.delete_ldirs)
         lp.m_logger.debug('Processed fw_id: {}'.format(f))
     lp.m_logger.info('Finished deleting {} WFs'.format(len(fw_ids)))
 
@@ -953,7 +953,10 @@ def lpad():
                                                       "Password or positive response to input prompt "
                                                       "required when modifying more than {} "
                                                       "entries.".format(PW_CHECK_NUM))
-    delete_wfs_parser.set_defaults(func=delete_wfs)
+    delete_wfs_parser.add_argument('--ldirs', help="the launch directories associated with the WF will "
+                                                   "be deleted as well, if possible", dest="delete_ldirs",
+                                   action='store_true')
+    delete_wfs_parser.set_defaults(func=delete_wfs, delete_ldirs=False)
 
     get_qid_parser = subparsers.add_parser('get_qids', help='get the queue id of a Firework')
     get_qid_parser.add_argument(*fw_id_args, **fw_id_kwargs)


### PR DESCRIPTION
This PR introduces the possibility to delete all the launch directories associated with a workflow when calling delete_wf. I often use this option when deleting failed workflows, in order to avoid leaving large unreferenced temporary files in the file system. 
I thought that this may be of general interest.
If this is the case, two further modifications could be considered:
-  print the launch directories and add a check from the user before actually deleting them
- add warnings in case shutil.rmtree fails to delete the directory (with "onerror")