### PR TITLE
update fireworks' fw_ids in bulk insert

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -341,6 +341,8 @@ class LaunchPad(FWSerializable):
             old_new = dict(zip(
                 wf.id_fw.keys(),
                 range(new_fw_counter, new_fw_counter + len(wf.fws))))
+            for fw in wf.fws:
+                fw.fw_id = old_new[fw.fw_id]
             wf._reassign_ids(old_new)
             new_fw_counter += len(wf.fws)
 


### PR DESCRIPTION
While testing the new `bulk_add_wfs` function I realized that the fw_id are inserted with negative values in the fireworks collection. They should be updated explicitly also in the Fireworks instances before insert.