### PR TITLE
Add signal to SLURM template

### DIFF
--- a/fireworks/user_objects/queue_adapters/SLURM_template.txt
+++ b/fireworks/user_objects/queue_adapters/SLURM_template.txt
@@ -14,6 +14,7 @@
 #SBATCH --output=$${job_name}-%j.out
 #SBATCH --error=$${job_name}-%j.error
 #SBATCH --constraint=$${constraint}
+#SBATCH --signal=$${signal}
 
 $${pre_rocket}
 cd $${launch_dir}


### PR DESCRIPTION
Adding signal to the SLURM template. This can be used to tell SLURM to send a signal to the running proc before wall time. Especially useful to ensure you don't lose runs. 