### PR TITLE
fixed lpad cli when performing wflow operations

### DIFF
--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -76,7 +76,7 @@ def parse_helper(lp, args, wf_mode=False, skip_pw=False):
         return pw_check(args.fw_id, args, skip_pw)
     if args.query:
         query = ast.literal_eval(args.query)
-    if args.name and not args.launches_mode:
+    if args.name and 'launches_mode' in args and not args.launches_mode:
         query['name'] = args.name
     if args.state:
         query['state'] = args.state


### PR DESCRIPTION
Most of the `lpad X_wflows -n NAME` functions don't work, this fixes that.

previously gave "Namespace has no attribute 'launches_mode'":

```
(gcmcworkflow) richards-imac:[~/test/gcmcworkflowtest]:$ lpad delete_wflows -n test
Traceback (most recent call last):
  File "/Users/richardgowers/miniconda3/envs/gcmcworkflow/bin/lpad", line 11, in <module>
    sys.exit(lpad())
  File "/Users/richardgowers/miniconda3/envs/gcmcworkflow/lib/python3.6/site-packages/fireworks/scripts/lpad_run.py", line 1127, in lpad
    args.func(args)
  File "/Users/richardgowers/miniconda3/envs/gcmcworkflow/lib/python3.6/site-packages/fireworks/scripts/lpad_run.py", line 322, in delete_wfs
    fw_ids = parse_helper(lp, args, wf_mode=True)
  File "/Users/richardgowers/miniconda3/envs/gcmcworkflow/lib/python3.6/site-packages/fireworks/scripts/lpad_run.py", line 79, in parse_helper
    if args.name and not args.launches_mode:
AttributeError: 'Namespace' object has no attribute 'launches_mode'
```