### PR TITLE
WIP Add test for pymongo 3.7 auth problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     docker:
       - image: circleci/python:3.6.2
         environment:
-          FW_CONFIG_FILE: "~/fireworks/tests/FW_config_unittest.yaml"
+          FW_CONFIG_FILE: "$CIRCLE_WORKING_DIRECTORY/tests/FW_config_unittest.yaml"
       - image: circleci/mongo:3.6
         command: [--auth]
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,6 @@ jobs:
     working_directory: ~/fireworks
     docker:
       - image: circleci/python:3.6.2
-        environment:
-          FW_CONFIG_FILE: "$CIRCLE_WORKING_DIRECTORY/tests/FW_config_unittest.yaml"
       - image: circleci/mongo:3.6
         command: [--auth]
     steps:
@@ -35,4 +33,4 @@ jobs:
           name: Run fireworks tests
           command: |
             source ~/tox_env/bin/activate
-            tox
+            FW_CONFIG_FILE="$CIRCLE_WORKING_DIR gsECTORY/tests/FW_config_unittest.yaml" tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - image: circleci/python:3.6.2
         environment:
           FW_CONFIG_FILE: "~/fireworks/tests/FW_config_unittest.yaml"
-      - image: circleci/mongo:latest
+      - image: circleci/mongo:3.6
         command: [--auth]
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,10 @@ jobs:
     working_directory: ~/fireworks
     docker:
       - image: circleci/python:3.6.2
+        environment:
+          FW_CONFIG_FILE: "~/fireworks/tests/FW_config_unittest.yaml"
       - image: circleci/mongo:latest
+        command: [--auth]
     steps:
       - checkout
       - run:
@@ -15,6 +18,19 @@ jobs:
             python -m venv ~/tox_env
             source ~/tox_env/bin/activate
             pip install tox tox-pyenv
+      - run:
+          name: Install MongoDB Shell 3.6 for Ubuntu Trusty
+          command: |
+            sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+            echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+            sudo apt-get update
+            sudo apt-get install -y --force-yes mongodb-org-shell
+      # Config
+      - run:
+          name: Configure MongoDB
+          command: |
+            mongo admin --eval 'db.createUser({ user: "admin", pwd: "admin", roles: [{ role: "userAdminAnyDatabase", db: "admin" }]})'
+            mongo fireworks_unittest -u admin -p admin --authenticationDatabase admin --eval 'db.createUser({ user: "fwuser", pwd: "fwpass", roles: [{ role: "dbOwner", db: "fireworks_unittest" }]})'
       - run:
           name: Run fireworks tests
           command: |

--- a/fireworks/tests/FW_config_unittest.yaml
+++ b/fireworks/tests/FW_config_unittest.yaml
@@ -1,0 +1,1 @@
+LAUNCHPAD_LOC: ~/fireworks/tests/my_launchpad_unittest.yaml

--- a/fireworks/tests/FW_config_unittest.yaml
+++ b/fireworks/tests/FW_config_unittest.yaml
@@ -1,1 +1,1 @@
-LAUNCHPAD_LOC: ~/fireworks/tests/my_launchpad_unittest.yaml
+LAUNCHPAD_LOC: $CIRCLE_WORKING_DIRECTORY/tests/my_launchpad_unittest.yaml

--- a/fireworks/tests/cmd_line_test.sh
+++ b/fireworks/tests/cmd_line_test.sh
@@ -23,3 +23,8 @@ test_cmd lpad -l fireworks/tests/my_launchpad_unittest.yaml append_wflow -i 1 -f
 test_cmd lpad -l fireworks/tests/my_launchpad_unittest.yaml dump_wflow -i 1 -f test_dump_wflow.json && rm -f test_dump_wflow.json
 test_cmd rlaunch -l fireworks/tests/my_launchpad_unittest.yaml singleshot
 test_cmd lpad -l fireworks/tests/my_launchpad_unittest.yaml delete_wflows -i 1
+
+test_cmd lpad add_scripts 'echo "hello"' 'echo "goodbye"' -n hello goodbye -w test_workflow
+test_cmd rlaunch --silencer singleshot
+test_cmd lpad delete_wflows -i 1
+

--- a/fireworks/tests/my_launchpad_unittest.yaml
+++ b/fireworks/tests/my_launchpad_unittest.yaml
@@ -1,7 +1,9 @@
 host: localhost
 port: 27017
 name: fireworks_unittest
-username: null
-password: null
+username: fwuser
+password: fwpass
+admin_user: fwuser
+admin_password: fwpass
 logdir: null
 strm_lvl: INFO


### PR DESCRIPTION
This is a supplement to #299. I'm not sure if this change to `.circleci/config.yml` will ensure all existing tests pass.

The minimal reproduction of the error is to run through the [quickstart](https://materialsproject.github.io/fireworks/quickstart.html) example of adding and running a workflow, but for a launchpad that requires authentication:

```
lpad add_scripts 'echo "hello"' 'echo "goodbye"' -n hello goodbye -w test_workflow
rlaunch --silencer singleshot
```
It works with pymongo 3.6.x, but fails for pymongo 3.7 with `pymongo.errors.OperationFailure: Authentication failed.`.

I don't know how to solve this issue -- I'm just hoping to contribute a failing test.