### PR TITLE
Improve high dependency firework performance

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -982,16 +982,15 @@ class Workflow(FWSerializable):
             self.fw_states[fw_id] = fw.state
             return updated_ids
 
-        # what are the parent states?
-        parent_states = [self.id_fw[p].state for p in self.links.parent_links.get(fw_id, [])]
-
         completed_parent_states = ['COMPLETED']
         if fw.spec.get('_allow_fizzled_parents'):
             completed_parent_states.append('FIZZLED')
 
-        if len(parent_states) != 0 and not all(s in completed_parent_states for s in parent_states):
-            m_state = 'WAITING'
-
+        # check parent states for any that are not completed
+        for parent in self.links.parent_links.get(fw_id, []):
+            if self.id_fw[parent].state not in completed_parent_states:
+                m_state = 'WAITING'
+                break
         else:  # not DEFUSED/ARCHIVED, and all parents are done running. Now the state depends on the launch status
             # my state depends on launch whose state has the highest 'score' in STATE_RANKS
             m_launch = self._get_representative_launch(fw)


### PR DESCRIPTION
For workflows with fireworks that have a lot of dependencies, the current code can take a long time.  Instead of getting the state of all parents and checking if all of those states are a completed state, we can check for the first parent that is not completed and exit early.  This isn't guaranteed to improve performance since the last parent in the list could be the only one that isn't complete but from what I've seen so far, the last parent to run/complete is usually the first checked in this list.

I have created a simple test script to show the difference in execution time [here](https://github.com/tahorst/fireworks/blob/master/test_high_dependencies.py) (but not included in this PR).  With my setup and 500 dependent tasks, the execution time between the task completing and the rocket finishing goes from 40 sec to ~1.5 sec.