### PR TITLE
Addition of memory options to SLURM queue template

### DIFF
--- a/fireworks/user_objects/queue_adapters/SLURM_template.txt
+++ b/fireworks/user_objects/queue_adapters/SLURM_template.txt
@@ -17,6 +17,9 @@
 #SBATCH --error=$${job_name}-%j.error
 #SBATCH --constraint=$${constraint}
 #SBATCH --signal=$${signal}
+#SBATCH --mem=$${mem}
+#SBATCH --mem-per-cpu=$${mem_per_cpu}
+
 
 $${pre_rocket}
 cd $${launch_dir}


### PR DESCRIPTION
Added two new queue adapter options: --mem and --mem-per-cpu to SLURM template.  This is useful for me and figured I would share it with the community at large.