### PR TITLE
fix regression when rerunning one firework with dependencies 

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -868,7 +868,7 @@ class Workflow(FWSerializable):
         # re-run all the children
         for child_id in self.links[fw_id]:
             if self.id_fw[child_id].state != 'WAITING':
-                # self.refresh(fw_id, updated_ids)
+                self.refresh(fw_id, updated_ids)
                 updated_ids = updated_ids.union(self.rerun_fw(child_id, updated_ids))
 
         # refresh the WF to get the states updated

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -868,6 +868,7 @@ class Workflow(FWSerializable):
         # re-run all the children
         for child_id in self.links[fw_id]:
             if self.id_fw[child_id].state != 'WAITING':
+                # self.refresh(fw_id, updated_ids)
                 updated_ids = updated_ids.union(self.rerun_fw(child_id, updated_ids))
 
         # refresh the WF to get the states updated

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -865,14 +865,16 @@ class Workflow(FWSerializable):
         m_fw._rerun()
         updated_ids.add(fw_id)
 
+        # refresh the states of the current fw before rerunning the children
+        # so that they get the correct state of the parent.
+        updated_ids.union(self.refresh(fw_id, updated_ids))
+
         # re-run all the children
         for child_id in self.links[fw_id]:
             if self.id_fw[child_id].state != 'WAITING':
-                self.refresh(fw_id, updated_ids)
                 updated_ids = updated_ids.union(self.rerun_fw(child_id, updated_ids))
 
-        # refresh the WF to get the states updated
-        return self.refresh(fw_id, updated_ids)
+        return updated_ids
 
     def append_wf(self, new_wf, fw_ids, detour=False, pull_spec_mods=False):
         """

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -452,8 +452,17 @@ class LaunchPadDefuseReigniteRerunArchiveDeleteTest(unittest.TestCase):
         first_ldir = launches[0].launch_dir
         ts = datetime.datetime.utcnow()
 
+        # check that all the zeus children are completed
+        completed = set(self.lp.get_fw_ids({'state':'COMPLETED'}))
+        self.assertTrue(completed.issuperset(set(self.zeus_child_fw_ids)))
+
         # Rerun Zeus
         self.lp.rerun_fw(self.zeus_fw_id, rerun_duplicates=True)
+
+        # now the children should be waiting
+        completed = set(self.lp.get_fw_ids({'state':'WAITING'}))
+        self.assertTrue(completed.issuperset(set(self.zeus_child_fw_ids)))
+
         rapidfire(self.lp, self.fworker,m_dir=MODULE_DIR)
 
         fw = self.lp.get_fw_by_id(self.zeus_fw_id)


### PR DESCRIPTION
I have realized that this commit https://github.com/materialsproject/fireworks/commit/d9a71ac27cfd025af39f507137c407657e17dd38 have caused a regression. 
Consider the case with a fw `fw1` with one child `fw2` and the whole wf is completed. Trying to rerun `fw1` now results in having both `fw1` and `fw2` `READY`, instead of `fw2` being `WAITING`. 

Here is a piece of code demonstrating the problem 
```python
from fireworks import LaunchPad, Firework, Workflow
from fireworks.core.rocket_launcher import rapidfire
from fireworks.examples.custom_firetasks.hello_world.hello_world_task import HelloTask

lp = LaunchPad.auto_load()
#lp.reset()  

fw1 = Firework([HelloTask()])
fw2 = Firework([HelloTask()], parents=[fw1])
wf = Workflow([fw1, fw2])
old_new = lp.add_wf(wf)

fw_ids = list(old_new.values())

print("READY: {}".format(lp.get_fw_ids({"state": "READY", "fw_id": {"$in": fw_ids}})))
print("WAITING: {}".format(lp.get_fw_ids({"state": "WAITING", "fw_id": {"$in": fw_ids}})))

rapidfire(lp)

print("COMPLETED: {}".format(lp.get_fw_ids({"state": "COMPLETED", "fw_id": {"$in": fw_ids}})))

print("rerunning")
lp.rerun_fw(fw1.fw_id)

print("READY: {}".format(lp.get_fw_ids({"state": "READY", "fw_id": {"$in": fw_ids}})))
print("WAITING: {}".format(lp.get_fw_ids({"state": "WAITING", "fw_id": {"$in": fw_ids}})))
```

and its output

```
2018-10-19 15:30:58,521 INFO Added a workflow. id_map: {-2: 1, -1: 2}
READY: [2]
WAITING: [1]
2018-10-19 15:30:58,526 INFO Created new dir 
...
2018-10-19 15:30:58,578 INFO Rocket finished
COMPLETED: [1, 2]
rerunning
READY: [1, 2]
WAITING: []
```

The problem relies in the fact that now the parent state is not updated during the `refresh`of the child and since the refresh basically happens from the bottom the child still sees his parent as `COMPLETED`. 

It is likely that the solution implemented is not the best but it does not impact on the improvements introduced in https://github.com/materialsproject/fireworks/commit/d9a71ac27cfd025af39f507137c407657e17dd38. An alternative would be to add a flag to `refresh` that allows to explicitly pull the current state of the parent fws if needed, like in the old implementation.

I also modified one of the tests to help preventing this kind of regression.