### PR TITLE
[WIP] Solve DocumentTooLarge error for Launch

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -393,7 +393,7 @@ class Launch(FWSerializable, object):
     """
 
     def __init__(self, state, launch_dir, fworker=None, host=None, ip=None, trackers=None,
-                 action=None, action_gridfs_id=None, state_history=None, launch_id=None, fw_id=None):
+                 action=None, state_history=None, launch_id=None, fw_id=None):
         """
         Args:
             state (str): the state of the Launch (e.g. RUNNING, COMPLETED)
@@ -403,8 +403,6 @@ class Launch(FWSerializable, object):
             ip (str): the IP address where the launch took place (set automatically if None)
             trackers ([Tracker]): File Trackers for this Launch
             action (FWAction): the output of the Launch
-            action_gridfs_id (str): the document id of the gridfs file where the action is
-                stored in case the size of the Launch document exceeds the 16MB limit.
             state_history ([dict]): a history of all states of the Launch and when they occurred
             launch_id (int): launch_id set by the LaunchPad
             fw_id (int): id of the Firework this Launch is running
@@ -417,7 +415,6 @@ class Launch(FWSerializable, object):
         self.ip = ip or get_my_ip()
         self.trackers = trackers if trackers else []
         self.action = action if action else None
-        self.action_gridfs_id = action_gridfs_id
         self.state_history = state_history if state_history else []
         self.state = state
         self.launch_id = launch_id
@@ -530,7 +527,6 @@ class Launch(FWSerializable, object):
                 'ip': self.ip,
                 'trackers': self.trackers,
                 'action': self.action,
-                'action_gridfs_id': self.action_gridfs_id,
                 'state': self.state,
                 'state_history': self.state_history,
                 'launch_id': self.launch_id}
@@ -552,7 +548,7 @@ class Launch(FWSerializable, object):
         action = FWAction.from_dict(m_dict['action']) if m_dict.get('action') else None
         trackers = [Tracker.from_dict(f) for f in m_dict['trackers']] if m_dict.get('trackers') else None
         return Launch(m_dict['state'], m_dict['launch_dir'], fworker,
-                      m_dict['host'], m_dict['ip'], trackers, action, m_dict["action_gridfs_id"],
+                      m_dict['host'], m_dict['ip'], trackers, action,
                       m_dict['state_history'], m_dict['launch_id'], m_dict['fw_id'])
 
     def _update_state_history(self, state):

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -393,7 +393,7 @@ class Launch(FWSerializable, object):
     """
 
     def __init__(self, state, launch_dir, fworker=None, host=None, ip=None, trackers=None,
-                 action=None, state_history=None, launch_id=None, fw_id=None):
+                 action=None, action_gridfs_id=None, state_history=None, launch_id=None, fw_id=None):
         """
         Args:
             state (str): the state of the Launch (e.g. RUNNING, COMPLETED)
@@ -403,6 +403,8 @@ class Launch(FWSerializable, object):
             ip (str): the IP address where the launch took place (set automatically if None)
             trackers ([Tracker]): File Trackers for this Launch
             action (FWAction): the output of the Launch
+            action_gridfs_id (str): the document id of the gridfs file where the action is
+                stored in case the size of the Launch document exceeds the 16MB limit.
             state_history ([dict]): a history of all states of the Launch and when they occurred
             launch_id (int): launch_id set by the LaunchPad
             fw_id (int): id of the Firework this Launch is running
@@ -415,6 +417,7 @@ class Launch(FWSerializable, object):
         self.ip = ip or get_my_ip()
         self.trackers = trackers if trackers else []
         self.action = action if action else None
+        self.action_gridfs_id = action_gridfs_id
         self.state_history = state_history if state_history else []
         self.state = state
         self.launch_id = launch_id
@@ -527,6 +530,7 @@ class Launch(FWSerializable, object):
                 'ip': self.ip,
                 'trackers': self.trackers,
                 'action': self.action,
+                'action_gridfs_id': self.action_gridfs_id,
                 'state': self.state,
                 'state_history': self.state_history,
                 'launch_id': self.launch_id}
@@ -548,7 +552,7 @@ class Launch(FWSerializable, object):
         action = FWAction.from_dict(m_dict['action']) if m_dict.get('action') else None
         trackers = [Tracker.from_dict(f) for f in m_dict['trackers']] if m_dict.get('trackers') else None
         return Launch(m_dict['state'], m_dict['launch_dir'], fworker,
-                      m_dict['host'], m_dict['ip'], trackers, action,
+                      m_dict['host'], m_dict['ip'], trackers, action, m_dict["action_gridfs_id"],
                       m_dict['state_history'], m_dict['launch_id'], m_dict['fw_id'])
 
     def _update_state_history(self, state):

--- a/fireworks/core/tests/tasks.py
+++ b/fireworks/core/tests/tasks.py
@@ -75,3 +75,21 @@ class WaitWFLockTask(FiretaskBase):
             raise ValueError('Testing; this error is normal.')
 
         return FWAction(update_spec={"WaitWFLockTask": 1})
+
+@explicit_serialize
+class DoNothingTask(FiretaskBase):
+    def run_task(self, fw_spec):
+        pass
+
+@explicit_serialize
+class DetoursTask(FiretaskBase):
+    optional_params = ["n_detours", "data_per_detour"]
+
+    def run_task(self, fw_spec):
+        data_per_detour = self.get("data_per_detour", None)
+        n_detours = self.get("n_detours", 10)
+        fws = []
+        for i in range(n_detours):
+            fws.append(Firework([DoNothingTask(data=data_per_detour)]))
+
+        return FWAction(detours=fws)

--- a/fireworks/core/tests/tasks.py
+++ b/fireworks/core/tests/tasks.py
@@ -89,7 +89,7 @@ class DetoursTask(FiretaskBase):
         data_per_detour = self.get("data_per_detour", None)
         n_detours = self.get("n_detours", 10)
         fws = []
-        for i in range(n_detours):
+        for _ in range(n_detours):
             fws.append(Firework([DoNothingTask(data=data_per_detour)]))
 
         return FWAction(detours=fws)

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -1249,17 +1249,16 @@ class GridfsStoredDataTest(unittest.TestCase):
         self.assertEqual(fw.state, 'COMPLETED')
 
         launch_db = self.lp.launches.find_one({"launch_id":1})
-        assert len(launch_db["action"]["detours"]) == 0
+        self.assertIsNotNone(launch_db["action"]["gridfs_id"])
+        self.assertNotIn("detours", launch_db["action"])
 
-        assert self.lp.get_fw_ids(count_only=True) == 2001
+        self.assertEqual(self.lp.get_fw_ids(count_only=True), 2001)
 
         launch_full = self.lp.get_launch_by_id(1)
-        assert len(launch_full.action.detours) == 2000
-        assert launch_full.action_gridfs_id is not None
+        self.assertEqual(len(launch_full.action.detours), 2000)
 
         wf = self.lp.get_wf_by_fw_id_lzyfw(1)
-        assert len(wf.id_fw[1].launches[0].action.detours) == 2000
-        assert wf.id_fw[1].launches[0].action_gridfs_id is not None
+        self.assertEqual(len(wf.id_fw[1].launches[0].action.detours), 2000)
 
     def test_many_detours_offline(self):
         task = DetoursTask(n_detours=2000, data_per_detour=["a" * 100] * 100)
@@ -1279,10 +1278,11 @@ class GridfsStoredDataTest(unittest.TestCase):
         self.assertIsNone(self.lp.recover_offline(launch_id))
 
         launch_db = self.lp.launches.find_one({"launch_id": launch_id})
-        assert len(launch_db["action"]["detours"]) == 0
+        self.assertIsNotNone(launch_db["action"]["gridfs_id"])
+        self.assertNotIn("detours", launch_db["action"])
 
         launch_full = self.lp.get_launch_by_id(1)
-        assert len(launch_full.action.detours) == 2000
+        self.assertEqual(len(launch_full.action.detours), 2000)
 
 
 if __name__ == '__main__':

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -23,6 +23,7 @@ from fireworks.core.rocket_launcher import rapidfire, launch_rocket
 from fireworks.queue.queue_launcher import setup_offline_job
 from fireworks.user_objects.firetasks.script_task import ScriptTask, PyTask
 from fireworks.core.tests.tasks import ExceptionTestTask, ExecutionCounterTask, SlowAdditionTask, WaitWFLockTask
+from fireworks.core.tests.tasks import DetoursTask
 import fireworks.fw_config
 from monty.os import cd
 
@@ -1201,6 +1202,87 @@ class LaunchPadOfflineTest(unittest.TestCase):
         fw = self.lp.get_fw_by_id(launch_id)
 
         self.assertEqual(fw.state, 'FIZZLED')
+
+
+class GridfsStoredDataTest(unittest.TestCase):
+    """
+    Tests concerning the storage of data in Gridfs when the size of the
+    documents exceed the 16MB limit.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.lp = None
+        cls.fworker = FWorker()
+        try:
+            cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl='ERROR')
+            cls.lp.reset(password=None, require_password=False)
+        except:
+            raise unittest.SkipTest('MongoDB is not running in localhost:27017! Skipping tests.')
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.lp:
+            cls.lp.connection.drop_database(TESTDB_NAME)
+
+    def setUp(self):
+        self.old_wd = os.getcwd()
+
+    def tearDown(self):
+        self.lp.reset(password=None,require_password=False)
+        # Delete launch locations
+        if os.path.exists(os.path.join('FW.json')):
+            os.remove('FW.json')
+        os.chdir(self.old_wd)
+        for ldir in glob.glob(os.path.join(MODULE_DIR,"launcher_*")):
+            shutil.rmtree(ldir)
+
+    def test_many_detours(self):
+        task = DetoursTask(n_detours=2000, data_per_detour=["a" * 100] * 100)
+        fw = Firework([task])
+        self.lp.add_wf(fw)
+
+        rapidfire(self.lp, self.fworker, nlaunches=1)
+
+        fw = self.lp.get_fw_by_id(1)
+
+        self.assertEqual(fw.state, 'COMPLETED')
+
+        launch_db = self.lp.launches.find_one({"launch_id":1})
+        assert len(launch_db["action"]["detours"]) == 0
+
+        assert self.lp.get_fw_ids(count_only=True) == 2001
+
+        launch_full = self.lp.get_launch_by_id(1)
+        assert len(launch_full.action.detours) == 2000
+        assert launch_full.action_gridfs_id is not None
+
+        wf = self.lp.get_wf_by_fw_id_lzyfw(1)
+        assert len(wf.id_fw[1].launches[0].action.detours) == 2000
+        assert wf.id_fw[1].launches[0].action_gridfs_id is not None
+
+    def test_many_detours_offline(self):
+        task = DetoursTask(n_detours=2000, data_per_detour=["a" * 100] * 100)
+        fw = Firework([task])
+        self.lp.add_wf(fw)
+
+        launch_dir = os.path.join(MODULE_DIR, "launcher_offline")
+        os.makedirs(launch_dir)
+        fw, launch_id = self.lp.reserve_fw(self.fworker, launch_dir)
+        fw = self.lp.get_fw_by_id(1)
+        with cd(launch_dir):
+            setup_offline_job(self.lp, fw, launch_id)
+
+            # launch rocket without launchpad to trigger offline mode
+            launch_rocket(launchpad=None, fworker=self.fworker, fw_id=1)
+
+        self.assertIsNone(self.lp.recover_offline(launch_id))
+
+        launch_db = self.lp.launches.find_one({"launch_id": launch_id})
+        assert len(launch_db["action"]["detours"]) == 0
+
+        launch_full = self.lp.get_launch_by_id(1)
+        assert len(launch_full.action.detours) == 2000
 
 
 if __name__ == '__main__':

--- a/fireworks/fw_config.py
+++ b/fireworks/fw_config.py
@@ -99,6 +99,10 @@ WEBSERVER_PERFWARNINGS = False # enable performance-related warnings
 # documentation http://api.mongodb.org/python/current/api/pymongo/mongo_client.html
 MONGO_SOCKET_TIMEOUT_MS = 5 * 60 * 1000
 
+# name of the collection that will be used to store information in case the size of
+# a dynamically generated document exceeds the 16MB limit. Functionality disabled if None.
+GRIDFS_FALLBACK_COLLECTION = "fw_gridfs"
+
 
 def override_user_settings():
     module_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This PR addresses the problem discussed in #313.
At this stage I have implemented only the saving to gridfs. While I would have liked to include the option to switch to the deletion of the data, I came across a problem that I did not consider beforehand:  
at present, the call to `Workflow.apply_action` is performed inside `Workflow.refresh` and the Launch object used there is not the one available in `complete_launch`, so it is downloaded from the DB there. With this configuration, if the action is not stored anywhere it will not be applied. 

A possible workaround would be to make the launch an argument of `refresh` and propagate the original object from `complete_launch` (through `Launchpad._refresh_wf`), but I am not sure if it would be a good idea to do that just to allow this option.
Do you have any suggestion about how to avoid this problem in another way?


A couple of further notes on the current implementation: 
* I added a new attribute to the `Launch` to store the potential gridfs id instead of setting it in place of the `action`. This is to avoid potential serialization/deserialization problems if the content of the `action` attribute is not an `FWAction`.
* I purposedly tried to be general in the naming of this gridfs functionality instead of tying it explicitly to the action in Launch. So that, in case some other cases of `DocumentTooLarge` errors are identified, they could be dealt with in a similar manner and use the same collection. Is this fine or would you prefer to have different collections in case some other properties requiring gridfs will show up?
