### PR TITLE
Further authentication issues in LaunchPad construction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - run:
           name: Make tox env and setup mongo
           command: |
+            mongo not_the_admin_db --eval "db.createUser({user: \"myuser\", pwd: \"mypassword\", roles: [ \"dbOwner\" ]})"
             mkdir ~/tox_env
             python -m venv ~/tox_env
             source ~/tox_env/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,7 @@ jobs:
       - image: circleci/python:3.6.2
       - image: circleci/mongo:latest
         command: |
-          mongod
-          mongo not_the_admin_db --eval "db.createUser({user: \"myuser\", pwd: \"mypassword\", roles: [ \"dbOwner\" ]})"
+          mongod & mongo not_the_admin_db --eval "db.createUser({user: \"myuser\", pwd: \"mypassword\", roles: [ \"dbOwner\" ]})"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - image: circleci/python:3.6.2
       - image: circleci/mongo:latest
         command: |
+          mongod
           mongo not_the_admin_db --eval "db.createUser({user: \"myuser\", pwd: \"mypassword\", roles: [ \"dbOwner\" ]})"
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,6 @@ jobs:
     docker:
       - image: circleci/python:3.6.2
       - image: circleci/mongo:latest
-        command: |
-          mongod & mongo not_the_admin_db --eval "db.createUser({user: \"myuser\", pwd: \"mypassword\", roles: [ \"dbOwner\" ]})"
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,13 @@ jobs:
     docker:
       - image: circleci/python:3.6.2
       - image: circleci/mongo:latest
+        command: |
+          mongo not_the_admin_db --eval "db.createUser({user: \"myuser\", pwd: \"mypassword\", roles: [ \"dbOwner\" ]})"
     steps:
       - checkout
       - run:
           name: Make tox env and setup mongo
           command: |
-            mongo not_the_admin_db --eval "db.createUser({user: \"myuser\", pwd: \"mypassword\", roles: [ \"dbOwner\" ]})"
             mkdir ~/tox_env
             python -m venv ~/tox_env
             source ~/tox_env/bin/activate

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -155,7 +155,8 @@ class LaunchPad(FWSerializable):
         self.connection = MongoClient(host, port, ssl=self.ssl,
             ssl_ca_certs=self.ssl_ca_certs, ssl_certfile=self.ssl_certfile,
             ssl_keyfile=self.ssl_keyfile, ssl_pem_passphrase=self.ssl_pem_passphrase,
-            socketTimeoutMS=MONGO_SOCKET_TIMEOUT_MS, username=username, password=password)
+            socketTimeoutMS=MONGO_SOCKET_TIMEOUT_MS, username=username, password=password,
+            authSource=authsource)
         self.db = self.connection[name]
 
         self.fireworks = self.db.fireworks

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -156,7 +156,7 @@ class LaunchPad(FWSerializable):
             ssl_ca_certs=self.ssl_ca_certs, ssl_certfile=self.ssl_certfile,
             ssl_keyfile=self.ssl_keyfile, ssl_pem_passphrase=self.ssl_pem_passphrase,
             socketTimeoutMS=MONGO_SOCKET_TIMEOUT_MS, username=username, password=password,
-            authSource=authsource)
+            authSource=self.authsource)
         self.db = self.connection[name]
 
         self.fireworks = self.db.fireworks

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -18,6 +18,7 @@ import datetime
 from multiprocessing import Process
 import filecmp
 
+from pymongo import MongoClient
 from pymongo.errors import OperationFailure
 
 from fireworks import Firework, Workflow, LaunchPad, FWorker
@@ -36,6 +37,16 @@ MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 class AuthenticationTest(unittest.TestCase):
     """Tests whether users are authenticating agains the correct mongo dbs.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            client = MongoClient()
+            client.not_the_admin_db.command(
+                "createUser", "myuser", pwd="mypassword", roles=['dbOwner'])
+        except Exception:
+            raise unittest.SkipTest(
+                'MongoDB is not running in localhost:27017! Skipping tests.')
 
     def test_no_admin_privileges_for_plebs(self):
         """Normal users can not authenticate against the admin db.

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -43,7 +43,7 @@ class AuthenticationTest(unittest.TestCase):
         with self.assertRaises(OperationFailure):
             lp = LaunchPad(name="admin", username="myuser",
                            password="mypassword", authsource="admin")
-            lp.db.count()
+            lp.db.collection.count()
 
     def test_authenticating_to_users_db(self):
         """A user should be able to authenticate against a database that they
@@ -51,7 +51,7 @@ class AuthenticationTest(unittest.TestCase):
         """
         lp = LaunchPad(name="not_the_admin_db", username="myuser",
                        password="mypassword", authsource="not_the_admin_db")
-        lp.db.count()
+        lp.db.collection.count()
 
     def test_authsource_infered_from_db_name(self):
         """The default behavior is to authenticate against the db that the user
@@ -59,7 +59,7 @@ class AuthenticationTest(unittest.TestCase):
         """
         lp = LaunchPad(name="not_the_admin_db", username="myuser",
                        password="mypassword")
-        lp.db.count()
+        lp.db.collection.count()
 
 
 class LaunchPadTest(unittest.TestCase):


### PR DESCRIPTION
# Summary

After the last changes to `LaunchPad`, users were always authenticating against the admin database. Therefore, they could not access databases that they were users of. These changes ensure that a user is authenticating against the database that they want to access, and not the admin database by default.

* A *not_the_admin_db* database is created by circle ci with a single user *myuser*
* The `authSource` is always passed into the `MongoClient` constructor
* Tests ensure that *myuser* can only authenticate against the database that they are a part of
* Tests ensure that the `authSource` is inferred from the database that the user wants access to