### PR TITLE
corrected keyword 'function'->'func' and outputs string -> list

### DIFF
--- a/docs_rst/dataflow_tasks.rst
+++ b/docs_rst/dataflow_tasks.rst
@@ -158,9 +158,9 @@ PyTask::
           split: coffee beans
           task:
             _fw_name: PyTask
-            function: auxiliary.printurn
+            func: auxiliary.printurn
             inputs: [coffee beans]
-            outputs: coffee powder
+            outputs: [coffee powder]
         coffee beans: [arabica, robusta, liberica]
     - fw_id: 2
       name: Brew coffee
@@ -170,16 +170,16 @@ PyTask::
           split: coffee powder
           task:
             _fw_name: PyTask
-            function: auxiliary.printurn
+            func: auxiliary.printurn
             inputs: [coffee powder, water]
-            outputs: pure coffee
+            outputs: [pure coffee]
         water: workflowing water
     - fw_id: 3
       name: Serve coffee
       spec:
         _tasks:
         - _fw_name: PyTask
-          function: auxiliary.printurn
+          func: auxiliary.printurn
           inputs: [pure coffee]
     links:
       '1': [2]

--- a/docs_rst/pytask.rst
+++ b/docs_rst/pytask.rst
@@ -59,18 +59,18 @@ Here is an example of using PyTask in a dataflow context::
       spec:
         _tasks:
         - _fw_name: PyTask
-          function: auxiliary.printurn
+          func: auxiliary.printurn
           inputs: [coffee beans]
-          outputs: coffee powder
+          outputs: [coffee powder]
         coffee beans: best selection
     - fw_id: 2
       name: Brew coffee
       spec:
         _tasks:
         - _fw_name: PyTask
-          function: auxiliary.printurn
+          func: auxiliary.printurn
           inputs: [coffee powder, water]
-          outputs: pure coffee
+          outputs: [pure coffee]
         water: workflowing water
     links:
       '1': [2]


### PR DESCRIPTION
Recently I discovered keyword and type inconsistencies in two examples in the upstream/master branch. These inconsistencies seem to be leftovers after refactoring the PyTask before a merge some time ago. The relevant tests are not affected of course.