### PR TITLE
Offline LaunchPad

### DIFF
--- a/fireworks/__init__.py
+++ b/fireworks/__init__.py
@@ -10,6 +10,7 @@ from fireworks.core.firework import FiretaskBase, FireTaskBase, Firework, Launch
     FWAction, Tracker
 from fireworks.core.fworker import FWorker
 from fireworks.core.launchpad import LaunchPad
+from fireworks.core.offline_launchpad import OfflineLaunchPad
 from fireworks.utilities.fw_utilities import explicit_serialize
 from fireworks.user_objects.firetasks.script_task import ScriptTask, PyTask
 from fireworks.user_objects.firetasks.fileio_tasks import FileDeleteTask, FileTransferTask, \

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -3,10 +3,12 @@
 """
 # https://stackoverflow.com/questions/11875770/how-to-overcome-datetime-datetime-not-json-serializable
 from bson import json_util
+import datetime
 import json
 import pathlib
+import sqlite3
 
-from .firework import Firework, Workflow
+from .firework import Firework, Workflow, Launch
 
 
 class Collection(object):
@@ -32,12 +34,26 @@ class Collection(object):
             f.write(json.dumps(content,
                                default=json_util.default))
 
+    def find_one(self, **kwargs):
+        for item in self.rootdir.glob('*json'):
+            with item.open('r') as f:
+                stuff = json.loads(f.read(),
+                                   object_hook=json_util.object_hook)
+                if all(stuff[k] == kwargs[k]
+                       for k in kwargs):
+                    return stuff
+
 
 class OfflineLaunchPad(object):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, logdir=None, **kwargs):
+        self._db = sqlite3.connect(':memory:')
+
         self._metadata = Collection('.launchpad', 'metadata')
-        self.fireworks = Collection('.launchpad', 'firework')
-        self.workflows = Collection('.launchpad', 'workflow')
+        self.fireworks = Collection('.launchpad', 'fireworks')
+        self.workflows = Collection('.launchpad', 'workflows')
+        self.launches = Collection('.launchpad', 'launches')
+
+        self.logdir = logdir
 
     def to_dict(self):
         raise NotImplementedError
@@ -54,7 +70,16 @@ class OfflineLaunchPad(object):
         raise NotImplementedError
 
     def reset(self, *args, **kwargs):
-        raise NotImplementedError
+        with self._db as c:
+            # reset count of ids
+            c.execute('DROP TABLE IF EXISTS meta')
+            c.execute('CREATE TABLE meta(name TEXT, value INTEGER)')
+            c.executemany('INSERT INTO meta VALUES(?, 1)',
+                          [('next_fw_id',), ('next_launch_id',)])
+            c.execute('DROP TABLE IF EXISTS fireworks')
+            c.execute('''CREATE TABLE fireworks(fw_id INTEGER,
+                                                state TEXT,
+                                                data TEXT)''')
 
     def maintain(self, **kwargs):
         raise NotImplementedError
@@ -102,7 +127,20 @@ class OfflineLaunchPad(object):
         raise NotImplementedError
 
     def get_wf_by_fw_id_lzyfw(self, fw_id):
-        raise NotImplementedError
+        wf = self.workflows.find_one(fw_id=fw_id)
+
+        fws = [LazyFirework(fw_id, self.fireworks, self.launches)
+               for fw_id in wf['nodes']]
+
+        if 'fw_states' in wf:
+            fw_states = dict([(int(k), v)
+                              for (k, v) in wf['fw_states'].items()])
+        else:
+            fw_states = None
+
+        return Workflow(fws, wf['links'], wf['name'],
+                        wf['metadata'], wf['created_on'],
+                        wf['updated_on'], fw_states)
 
     def delete_wf(self, fw_id, delete_launch_dirs=False):
         raise NotImplementedError
@@ -156,7 +194,20 @@ class OfflineLaunchPad(object):
         raise NotImplementedError
 
     def _get_a_fw_to_run(self, query=None, fw_id=None, checkout=True):
-        raise NotImplementedError
+        # some stuff about priority todo
+
+        if fw_id:
+            firework = self.fireworks.read(str(fw_id))
+        else:
+            firework = self.fireworks.find_one(state='READY')
+
+        if checkout:
+            firework.state = 'RESERVED'
+            firework.updated_on = datetime.datetime.utcnow()
+
+            self.fireworks.write(str(fw_id), firework)
+
+
 
     def _get_active_launch_ids(self):
         raise NotImplementedError
@@ -190,12 +241,45 @@ class OfflineLaunchPad(object):
 
     def checkout_fw(self, fworker, launch_dir, fw_id=None, host=None,
                     ip=None, state="RUNNING"):
-        raise NotImplementedError
+        m_fw = self._get_a_fw_to_run(fworker.query, fw_id=fw_id)
+        if not m_fw:
+            return None, None
+
+        # TODO: reserved launch stuff
+        reserved_launch = False
+
+        launch_id = (reserved_launch.launch_id if reserved_launch
+                     else self.get_new_launch_id())
+
+        # TODO: trackers
+        trackers=None
+
+        m_launch = Launch(state, launch_dir, fworker, host, ip,
+                          trackers=trackers, state_history=None,
+                          launch_id=launch_id, fw_id=m_fw.fw_id)
+
+        self.launches.write(str(m_launch.launch_id),
+                            m_launch)
+
+        if not reserved_launch:
+            m_fw.launches.append(m_launch)
+        else:
+            raise NotImplementedError
+
+        m_fw.state = state
+        self._upsert_fws([m_fw])
+        self._refresh_wf(m_fw.fw_id)
+
+        # TODO: Duplicate run stuff
+        # if state == "RUNNING"
+
+        # TODO: Backup fw_data?
 
     def change_launch_dir(self, launch_id, launch_dir):
         raise NotImplementedError
 
     def restore_backup_data(self, launch_id, fw_id):
+        # Doesn't seem to ever be used by anything, can ignore
         raise NotImplementedError
 
     def complete_launch(self, launch_id, action=None, state='COMPLETED'):
@@ -204,17 +288,21 @@ class OfflineLaunchPad(object):
     def ping_launch(self, launch_id, ptime=None, checkpoint=None):
         raise NotImplementedError
 
-    def get_new_fw_id(self, quantity=1):
-        try:
-            next_id = self._metadata.read('next_fw_id')
-        except FileNotFoundError:
-            next_id = 1
-        self._metadata.write('next_fw_id', next_id + quantity)
+    def _get_new_and_increment(self, table, increment):
+        with self._db as c:
+            c2 = c.execute('SELECT value FROM meta WHERE name = ?',
+                           (table,))
+            next_id = c2.fetchone()[0]
+            c.execute('UPDATE meta SET value = ? WHERE name = ?',
+                      (next_id + increment, table))
 
         return next_id
 
+    def get_new_fw_id(self, quantity=1):
+        return self._get_new_and_increment('next_fw_id', quantity)
+
     def get_new_launch_id(self):
-        raise NotImplementedError
+        return self._get_new_and_increment('next_launch_id', 1)
 
     def _upsert_fws(self, fws, reassign_all=False):
         """Insert into Fireworks 'collection'"""
@@ -230,14 +318,22 @@ class OfflineLaunchPad(object):
                 fw.fw_id = new_id
                 used_ids.append(new_id)
 
-            self.fireworks.write(str(fw.fw_id), fw.to_db_dict())
+            with self._db as c:
+                # delete rows that existed
+                # TODO: How to use 'WHERE fw_id IN used_ids'?
+                c.executemany('DELETE FROM fireworks WHERE fw_id = ?',
+                              [(i,) for i in used_ids])
+                c.executemany('INSERT INTO fireworks VALUES(?,?,?)',
+                              [self._fw_to_sqlite(fw) for fw in fws])
         else:
             for fw in fws:
                 if fw.fw_id < 0:
                     new_id = self.get_new_fw_id()
                     old_new[fw.fw_id] = new_id
                     fw.fw_id = new_id
-                self.fireworks.write(str(fw.fw_id), fw.to_db_dict())
+            with self._db as c:
+                c.executemany('INSERT INTO fireworks VALUES(?,?,?)',
+                              [self._fw_to_sqlite(fw) for fw in fws])
 
         return old_new
 
@@ -248,10 +344,28 @@ class OfflineLaunchPad(object):
         raise NotImplementedError
 
     def _refresh_wf(self, fw_id):
-        raise NotImplementedError
+        # TODO: Locks
+        wf = self.get_wf_by_fw_id_lzyfw(fw_id)
+        updated_ids = wf.refresh(fw_id)
+        self._update_wf(wf, updated_ids)
+        # TODO: Extra junk in the 2nd except branch
 
     def _update_wf(self, wf, updated_ids):
-        raise NotImplementedError
+        updated_fws = [wf.id_fw[fid] for fid in updated_ids]
+        old_new = self._upsert_fws(updated_fws)
+        wf._reassign_ids(old_new)
+
+        query_node = None
+        for f in wf.id_fw:
+            if f not in old_new.values() or old_new.get(f, None) == f:
+                query_node = f
+                break
+        else:
+            raise ValueError
+
+        wf = wf.to_db_dict()
+        wf['locked'] = True
+        self.workflows.write('1', wf)
 
     def _steal_launches(self, thief_fw):
         raise NotImplementedError
@@ -260,7 +374,7 @@ class OfflineLaunchPad(object):
         raise NotImplementedError
 
     def get_logdir(self):
-        raise NotImplementedError
+        return self.logdir
 
     def add_offline_run(self):
         raise NotImplementedError
@@ -274,8 +388,13 @@ class OfflineLaunchPad(object):
     def get_tracker_data(self, fw_id):
         raise NotImplementedError
 
-    def get_launchdir(self, fw-id, launch_idx=-1):
+    def get_launchdir(self, fw_id, launch_idx=-1):
         raise NotImplementedError
 
     def log_message(self, level, message):
         raise NotImplementedError
+
+
+class LazyFirework(Firework):
+    # Yeah...
+    pass

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -466,7 +466,6 @@ class OfflineLaunchPad(object):
         # TODO: I've changed the API of this call, is this bad?
         # Inherits 'Lock' from calling function
         # in sqlite, 'Lock' is the context manager
-        print(updated_ids)
         updated_fws = [wf.id_fw[fid] for fid in updated_ids]
         old_new = self._upsert_fws(updated_fws)
         wf._reassign_ids(old_new)

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -81,11 +81,17 @@ def sqlite_to_launch(launch):
 
 
 class OfflineLaunchPad(object):
-    def __init__(self, *args, logdir=None, **kwargs):
-        self._db = sqlite3.connect(':memory:')
+    def __init__(self, address, *args, logdir=None, **kwargs):
+        self._address = address  # store how we got here
+        self._db = sqlite3.connect(address)
         with self._db as c:
             c.execute('PRAGMA foreign_keys = ON')
         self.logdir = logdir
+
+    def copy(self):
+        # can only use one connection per thread
+        # so this method creates a new connection for threads
+        return self.__class__(self._address)
 
     def to_dict(self):
         raise NotImplementedError

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -189,17 +189,12 @@ class OfflineLaunchPad(object):
     def append_wf(self, new_wf, fw_ids, detour=False, pull_spec_mods=True):
         # grab existing workflow
         wf = self.get_wf_by_fw_id(fw_ids[0])
-
         # call append_wf on that to get updated IDs
         updated_ids = wf.append_wf(new_wf, fw_ids, detour=detour,
                                    pull_spec_mods=pull_spec_mods)
         with self._db as c:
             # create firework stubs for new fireworks
             self._update_wf(wf, updated_ids, cursor=c)
-        # update affected fireworks
-        # insert new fireworks
-        # update workflow
-        raise NotImplementedError
 
     def get_launch_by_id(self, launch_id):
         with self._db as c:

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -230,14 +230,16 @@ class OfflineLaunchPad(object):
             raise NotImplementedError
         with self._db as c:
             # iterate over 'active' fireworks checking for waiting children
-            for fw in c.execute('SELECT * FROM fireworks '
+            for fw in c.execute('SELECT fw_id FROM fireworks '
                                 'WHERE state in ("RUNNING", "RESERVED")'):
+                fw_id = fw[0]  # sqlite returns tuple always
                 # TODO: Could optimise here by grouping into workflows
                 #       & fetch each unique workflow only once...
-                children = self.get_wf_by_fw_id_lzyfw(fw_id).links[fw_id]
+                # TODO: Make lazy again
+                children = self.get_wf_by_fw_id(fw_id).links[fw_id]
                 # If any children are "WAITING" then we've got future work
                 if c.execute('SELECT state FROM fireworks '
-                             'WHERE fw_id IN ' + _nq(len(children)) + ' ',
+                             'WHERE fw_id IN ' + _nq(len(children)) + ' '
                              'AND state = "WAITING"',
                              children):
                     return True

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -1,0 +1,91 @@
+"""Internet? Where we're going we don't need internet
+
+"""
+# https://stackoverflow.com/questions/11875770/how-to-overcome-datetime-datetime-not-json-serializable
+from bson import json_util
+import json
+import pathlib
+
+from .firework import Firework, Workflow
+
+
+class Collection(object):
+    """Mimics a MongoDB collection, kinda"""
+    def __init__(self, rootdir, name):
+        self.rootdir = pathlib.Path(rootdir) / name
+        if not self.rootdir.exists():
+            self.rootdir.mkdir(parents=True)
+
+    def read(self, item):
+        """Read given entry"""
+        item += '.json'
+
+        with (self.rootdir / item).open('r') as f:
+            return json.loads(f.read(),
+                              object_hook=json_util.object_hook)
+
+    def write(self, item, content):
+        """Write given entry, overwriting if exists"""
+        item += '.json'
+
+        with (self.rootdir / item).open('w') as f:
+            f.write(json.dumps(content,
+                               default=json_util.default))
+
+
+class OfflineLaunchPad(object):
+    def __init__(self, *args, **kwargs):
+        self._metadata = Collection('.launchpad', 'metadata')
+        self.fireworks = Collection('.launchpad', 'firework')
+        self.workflows = Collection('.launchpad', 'workflow')
+
+    def get_new_fw_id(self, quantity=1):
+        try:
+            next_id = self._metadata.read('next_fw_id')
+        except FileNotFoundError:
+            next_id = 1
+        self._metadata.write('next_fw_id', next_id + quantity)
+
+        return next_id
+
+    def _upsert_fws(self, fws, reassign_all=False):
+        """Insert into Fireworks 'collection'"""
+        old_new = {}
+        fws.sort(key=lambda x: x.fw_id)
+
+        if reassign_all:
+            used_ids = []
+            first_new_id = self.get_new_fw_id(quantity=len(fws))
+
+            for new_id, fw in enumerate(fws, start=first_new_id):
+                old_new[fw.fw_id] = new_id
+                fw.fw_id = new_id
+                used_ids.append(new_id)
+
+            self.fireworks.write(str(fw.fw_id), fw.to_db_dict())
+        else:
+            for fw in fws:
+                if fw.fw_id < 0:
+                    new_id = self.get_new_fw_id()
+                    old_new[fw.fw_id] = new_id
+                    fw.fw_id = new_id
+                self.fireworks.write(str(fw.fw_id), fw.to_db_dict())
+
+        return old_new
+
+    def add_wf(self, wf, reassign_all=True):
+        """Add WF to LaunchPad"""
+        if isinstance(wf, Firework):
+            wf = Workflow.from_Firework(wf)
+
+        for fw_id in wf.root_fw_ids:
+            wf.id_fw[fw_id].state = 'READY'
+            wf.fw_states[fw_id] = 'READY'
+
+        # "insert" and get new mapping of ids
+        old_new = self._upsert_fws(list(wf.id_fw.values()),
+                                   reassign_all=reassign_all)
+        wf._reassign_ids(old_new)
+        self.workflows.write('1', wf.to_db_dict())
+
+        return old_new

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -232,7 +232,7 @@ class OfflineLaunchPad(object):
                 children = self.get_wf_by_fw_id_lzyfw(fw_id).links[fw_id]
                 # If any children are "WAITING" then we've got future work
                 if c.execute('SELECT state FROM fireworks '
-                             'WHERE fw_id = ' + _nq(len(children)) + '',
+                             'WHERE fw_id IN ' + _nq(len(children)) + ' ',
                              'AND state = "WAITING"',
                              children):
                     return True
@@ -284,12 +284,13 @@ class OfflineLaunchPad(object):
         with self._db as c:
             if fw_id:
                 firework = c.execute('SELECT * FROM fireworks '
-                                     'WHERE fw_id = ?',
+                                     'WHERE fw_id = ? AND '
+                                     'state IN ("READY", "RESERVED")',
                                      (fw_id,)).fetchone()
             else:
                 # TODO: Ordering expected here
                 firework = c.execute('SELECT * FROM fireworks '
-                                     '').fetchone()
+                                     'WHERE state = "READY"').fetchone()
             if not firework is None:
                 firework = Firework.from_dict(sqlite_to_firework(firework))
                 if checkout:

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -417,7 +417,12 @@ class OfflineLaunchPad(object):
         return m_fw, launch_id
 
     def change_launch_dir(self, launch_id, launch_dir):
-        raise NotImplementedError
+        m_launch = self.get_launch_by_id(launch_id)
+        m_launch.launch_dir = launch_dir
+        with self._db as c:
+            c.execute('UPDATE launches SET data = ? '
+                      'WHERE launch_id = ?',
+                      (launch_to_sqlite(m_launch), launch_id))
 
     def restore_backup_data(self, launch_id, fw_id):
         # Doesn't seem to ever be used by anything, can ignore

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -101,6 +101,8 @@ class OfflineLaunchPad(object):
             c.execute('''CREATE TABLE workflows(wf_id INTEGER UNIQUE,
                                                 data TEXT)''')
             c.execute('DROP TABLE IF EXISTS mapping')
+            # TODO: Maybe store this inside the fireworks collection?
+            # ie add row of workflow_id values to fireworks schema
             c.execute('CREATE TABLE mapping(firework_id INTEGER UNIQUE, '
                       'workflow_id INTEGER, '
                       # all entries must match a fw_id in fireworks
@@ -111,6 +113,9 @@ class OfflineLaunchPad(object):
                       'FOREIGN KEY (workflow_id) REFERENCES workflows(wf_id) '
                       #'ON UPDATE CASCADE ON DELETE CASCADE)'
                       ')')
+            c.execute('DROP TABLE IF EXISTS launches')
+            c.execute('CREATE TABLE launches(launch_id INTEGER UNIQUE, '
+                      'data TEXT)')
 
     def maintain(self, **kwargs):
         raise NotImplementedError

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -81,12 +81,26 @@ def sqlite_to_launch(launch):
 
 
 class OfflineLaunchPad(object):
-    def __init__(self, address, *args, logdir=None, **kwargs):
+    def __init__(self, address=None, host='localhost',
+                 logdir=None, strm_lvl=None, user_indices=None,
+                 wf_user_indices=None):
+        if address is None:
+            # default location for sqlite file defined somewhere etc..
+            raise NotImplementedError
         self._address = address  # store how we got here
         self._db = sqlite3.connect(address)
         with self._db as c:
             c.execute('PRAGMA foreign_keys = ON')
+
+        self.host = host
+        # set up logger
         self.logdir = logdir
+        self.strm_lvl = strm_lvl if strm_lvl else 'INFO'
+        self.m_logger = get_fw_logger('launchpad', l_dir=self.logdir, stream_level=self.strm_lvl)
+
+        self.user_indices = user_indices if user_indices else []
+        self.wf_user_indices = wf_user_indices if wf_user_indices else []
+
 
     def copy(self):
         # can only use one connection per thread

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -85,17 +85,18 @@ class OfflineLaunchPad(object):
                            ('next_launch_id',),
                            ('next_workflow_id',)))
             c.execute('DROP TABLE IF EXISTS fireworks')
-            c.execute('''CREATE TABLE fireworks(fw_id INTEGER,
+            c.execute('''CREATE TABLE fireworks(fw_id INTEGER UNIQUE,
                                                 state TEXT,
                                                 data TEXT)''')
             c.execute('DROP TABLE IF EXISTS workflows')
-            c.execute('''CREATE TABLE workflows(wf_id INTEGER,
+            c.execute('''CREATE TABLE workflows(wf_id INTEGER UNIQUE,
                                                 data TEXT)''')
             c.execute('DROP TABLE IF EXISTS mapping')
-            c.execute('''CREATE TABLE mapping(firework_id INTEGER,
+            c.execute('''CREATE TABLE mapping(firework_id INTEGER UNIQUE,
                                               workflow_id INTEGER)''')
 
     def maintain(self, **kwargs):
+        # TODO: Just do sqlite VACUUM ?
         raise NotImplementedError
 
     def add_wf(self, wf, reassign_all=True):

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -109,22 +109,25 @@ class OfflineLaunchPad(object):
 
     def reset(self, *args, **kwargs):
         with self._db as c:
+            # Drop in correct order to not offend foreign key constraints
+            c.execute('DROP TABLE IF EXISTS launches')
+            c.execute('DROP TABLE IF EXISTS mapping')
+            c.execute('DROP TABLE IF EXISTS meta')
+            c.execute('DROP TABLE IF EXISTS workflows')
+            c.execute('DROP TABLE IF EXISTS fireworks')
+
             # TODO: Can squish these commands into single call?
             # reset count of ids
-            c.execute('DROP TABLE IF EXISTS meta')
             c.execute('CREATE TABLE meta(name TEXT, value INTEGER)')
             c.executemany('INSERT INTO meta VALUES(?, 1)',
                           (('next_fw_id',),
                            ('next_launch_id',),
                            ('next_workflow_id',)))
-            c.execute('DROP TABLE IF EXISTS fireworks')
             c.execute('''CREATE TABLE fireworks(fw_id INTEGER UNIQUE,
                                                 state TEXT,
                                                 data TEXT)''')
-            c.execute('DROP TABLE IF EXISTS workflows')
             c.execute('''CREATE TABLE workflows(wf_id INTEGER UNIQUE,
                                                 data TEXT)''')
-            c.execute('DROP TABLE IF EXISTS mapping')
             # TODO: Maybe store this inside the fireworks collection?
             # ie add row of workflow_id values to fireworks schema
             c.execute('CREATE TABLE mapping(firework_id INTEGER UNIQUE, '
@@ -137,7 +140,6 @@ class OfflineLaunchPad(object):
                       'FOREIGN KEY (workflow_id) REFERENCES workflows(wf_id) '
                       #'ON UPDATE CASCADE ON DELETE CASCADE)'
                       ')')
-            c.execute('DROP TABLE IF EXISTS launches')
             c.execute('CREATE TABLE launches(launch_id INTEGER UNIQUE, '
                       'fw_id INTEGER, '
                       'data TEXT, '

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -50,7 +50,8 @@ def sqlite_to_firework(firework):
     d = json.loads(data)
 
     d['fw_id'] = fw_id
-    d['state'] = state
+    if not state is None:
+        d['state'] = state
 
     return d
 
@@ -269,21 +270,22 @@ class OfflineLaunchPad(object):
             # let's smoke out where/if this is ever used
             raise NotImplementedError
 
-        # TODO: Case where no firework is found
         with self._db as c:
             if fw_id:
                 firework = c.execute('SELECT * FROM fireworks '
                                      'WHERE fw_id = ?',
                                      (fw_id,)).fetchone()
             else:
+                # TODO: Ordering expected here
                 firework = c.execute('SELECT * FROM fireworks ',
                                      '').fetchone()
-            firework = sqlite_to_firework(firework)
-            if checkout:
-                # TODO: Updated on field in fireworks schema
-                c.execute('UPDATE fireworks SET state = ? '
-                          'WHERE fw_id = ?',
-                          ("RESERVED", fw.fw_id))
+            if not firework is None:
+                firework = sqlite_to_firework(firework)
+                if checkout:
+                    # TODO: Updated on field in fireworks schema
+                    c.execute('UPDATE fireworks SET state = ? '
+                              'WHERE fw_id = ?',
+                              ("RESERVED", fw.fw_id))
 
         # TODO: Check for uniqueness
 

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -28,7 +28,13 @@ from bson import json_util as json
 import datetime
 import sqlite3
 
+from fireworks.utilities.fw_utilities import get_fw_logger
 from .firework import Firework, Workflow, Launch
+from .fworker import FWorker
+
+# this is a dict with some mongodb mumbo jumbo
+# we want to know what the default looks like to compare against later
+_DEFAULT_FWORKER_QUERY = FWorker().query
 
 
 def _nq(n):
@@ -277,7 +283,9 @@ class OfflineLaunchPad(object):
         raise NotImplementedError
 
     def run_exists(self, fworker=None):
-        if not fworker is None:
+        # we can't do custom queries yet
+        # so anything spicy gets rejected
+        if not (fworker.query == _DEFAULT_FWORKER_QUERY):
             raise NotImplementedError
         return bool(self._get_a_fw_to_run(query=None,
                                           checkout=False))
@@ -285,7 +293,7 @@ class OfflineLaunchPad(object):
     def future_run_exists(self, fworker=None):
         if self.run_exists(fworker):
             return True
-        if not fworker is None:
+        if not (fworker.query == _DEFAULT_FWORKER_QUERY):
             raise NotImplementedError
         with self._db as c:
             # iterate over 'active' fireworks checking for waiting children

--- a/fireworks/core/offline_launchpad.py
+++ b/fireworks/core/offline_launchpad.py
@@ -39,6 +39,171 @@ class OfflineLaunchPad(object):
         self.fireworks = Collection('.launchpad', 'firework')
         self.workflows = Collection('.launchpad', 'workflow')
 
+    def to_dict(self):
+        raise NotImplementedError
+
+    def update_specs(self, fw_ids, spec_document, mongo=False):
+        raise NotImplementedError
+
+    @classmethod
+    def from_dict(cls, d):
+        raise NotImplementedError
+
+    @classmethod
+    def auto_loc(cls):
+        raise NotImplementedError
+
+    def reset(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def maintain(self, **kwargs):
+        raise NotImplementedError
+
+    def add_wf(self, wf, reassign_all=True):
+        """Add WF to LaunchPad"""
+        if isinstance(wf, Firework):
+            wf = Workflow.from_Firework(wf)
+
+        for fw_id in wf.root_fw_ids:
+            wf.id_fw[fw_id].state = 'READY'
+            wf.fw_states[fw_id] = 'READY'
+
+        # "insert" and get new mapping of ids
+        old_new = self._upsert_fws(list(wf.id_fw.values()),
+                                   reassign_all=reassign_all)
+        wf._reassign_ids(old_new)
+        self.workflows.write('1', wf.to_db_dict())
+
+        return old_new
+
+    def bulk_add_wfs(self, wfs):
+        raise NotImplementedError
+
+    def append_wf(self, new_wf, fw_ids, detour=False, pull_spec_mods=True):
+        raise NotImplementedError
+
+    def get_launch_by_id(self, launch_id):
+        raise NotImplementedError
+
+    def get_fw_dict_by_id(self, fw_id):
+        try:
+            fw_dict = self.fireworks.load(str(fw_id))
+        except FileNotFoundError:
+            raise ValueError
+
+        return fw_dict
+
+    def get_fw_by_id(self, fw_id):
+        return Firework.from_dict(self.get_fw_dict_by_id(fw_id))
+
+    def get_wf_by_fw_id(self, fw_id):
+        # search through all Workflows, looking for correct fw_id?
+        # or could have some index file, but this could get stale
+        raise NotImplementedError
+
+    def get_wf_by_fw_id_lzyfw(self, fw_id):
+        raise NotImplementedError
+
+    def delete_wf(self, fw_id, delete_launch_dirs=False):
+        raise NotImplementedError
+
+    def get_wf_summary_dict(self, fw_id, mode='more'):
+        raise NotImplementedError
+
+    def get_fw_ids(self, **kwargs):
+        raise NotImplementedError
+
+    def get_wf_ids(self, **kwargs):
+        raise NotImplementedError
+
+    def run_exists(self, fworker=None):
+        raise NotImplementedError
+
+    def future_run_exists(self, fworker=None):
+        raise NotImplementedError
+
+    def tuneup(self, bkground=True):
+        raise NotImplementedError
+
+    def pause_fw(self, fw_id):
+        raise NotImplementedError
+
+    def defuse_fw(self, fw_id, rerun_duplicates=True):
+        raise NotImplementedError
+
+    def reignite_fw(self, fw_id):
+        raise NotImplementedError
+
+    def resume_fw(self, fw_id):
+        raise NotImplementedError
+
+    def defuse_wf(self, fw_id, defuse_all_states=True):
+        raise NotImplementedError
+
+    def pause_wf(self, fw_id):
+        raise NotImplementedError
+
+    def reignite_wf(self, fw_id):
+        raise NotImplementedError
+
+    def archive_wf(self, fw_id):
+        raise NotImplementedError
+
+    def _restart_ids(self, next_fw_id, next_launch_id):
+        raise NotImplementedError
+
+    def _check_fw_for_uniqueness(self, m_fw):
+        raise NotImplementedError
+
+    def _get_a_fw_to_run(self, query=None, fw_id=None, checkout=True):
+        raise NotImplementedError
+
+    def _get_active_launch_ids(self):
+        raise NotImplementedError
+
+    def reserve_fws(slef, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_fw_ids_from_reservation_id(self, reservation_id):
+        raise NotImplementedError
+
+    def cancel_reservation_by_reservation_id(self, reservation_id):
+        raise NotImplementedError
+
+    def get_reservation_id_from_fw_id(self, fw_id):
+        raise NotImplementedError
+
+    def cancel_reservation(self, launch_id):
+        raise NotImplementedError
+
+    def detect_unreserved(self, **kwargs):
+        raise NotImplementedError
+
+    def mark_fizzled(self, launch_id):
+        raise NotImplementedError
+
+    def detect_lostruns(self, **kwargs):
+        raise NotImplementedError
+
+    def set_reservation_id(self, launch_id, reservation_id):
+        raise NotImplementedError
+
+    def checkout_fw(self, fworker, launch_dir, fw_id=None, host=None,
+                    ip=None, state="RUNNING"):
+        raise NotImplementedError
+
+    def change_launch_dir(self, launch_id, launch_dir):
+        raise NotImplementedError
+
+    def restore_backup_data(self, launch_id, fw_id):
+        raise NotImplementedError
+
+    def complete_launch(self, launch_id, action=None, state='COMPLETED'):
+        raise NotImplementedError
+
+    def ping_launch(self, launch_id, ptime=None, checkpoint=None):
+        raise NotImplementedError
+
     def get_new_fw_id(self, quantity=1):
         try:
             next_id = self._metadata.read('next_fw_id')
@@ -47,6 +212,9 @@ class OfflineLaunchPad(object):
         self._metadata.write('next_fw_id', next_id + quantity)
 
         return next_id
+
+    def get_new_launch_id(self):
+        raise NotImplementedError
 
     def _upsert_fws(self, fws, reassign_all=False):
         """Insert into Fireworks 'collection'"""
@@ -73,19 +241,41 @@ class OfflineLaunchPad(object):
 
         return old_new
 
-    def add_wf(self, wf, reassign_all=True):
-        """Add WF to LaunchPad"""
-        if isinstance(wf, Firework):
-            wf = Workflow.from_Firework(wf)
+    def rerun_fw(self, fw_id, **kwargs):
+        raise NotImplementedError
 
-        for fw_id in wf.root_fw_ids:
-            wf.id_fw[fw_id].state = 'READY'
-            wf.fw_states[fw_id] = 'READY'
+    def get_recovery(self, fw_id, launch_id='last'):
+        raise NotImplementedError
 
-        # "insert" and get new mapping of ids
-        old_new = self._upsert_fws(list(wf.id_fw.values()),
-                                   reassign_all=reassign_all)
-        wf._reassign_ids(old_new)
-        self.workflows.write('1', wf.to_db_dict())
+    def _refresh_wf(self, fw_id):
+        raise NotImplementedError
 
-        return old_new
+    def _update_wf(self, wf, updated_ids):
+        raise NotImplementedError
+
+    def _steal_launches(self, thief_fw):
+        raise NotImplementedError
+
+    def set_priority(self, fw_id, priority):
+        raise NotImplementedError
+
+    def get_logdir(self):
+        raise NotImplementedError
+
+    def add_offline_run(self):
+        raise NotImplementedError
+
+    def recover_offline(self):
+        raise NotImplementedError
+
+    def forget_offline(self):
+        raise NotImplementedError
+
+    def get_tracker_data(self, fw_id):
+        raise NotImplementedError
+
+    def get_launchdir(self, fw-id, launch_idx=-1):
+        raise NotImplementedError
+
+    def log_message(self, level, message):
+        raise NotImplementedError

--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -30,6 +30,7 @@ from fireworks.fw_config import FWData, PING_TIME_SECS, REMOVE_USELESS_DIRS, \
     PRINT_FW_YAML, STORE_PACKING_INFO, ROCKET_STREAM_LOGLEVEL
 from fireworks.utilities.dict_mods import apply_mod
 from fireworks.core.launchpad import LockedWorkflowError, LaunchPad
+from fireworks.core.offline_launchpad import OfflineLaunchPad
 from fireworks.utilities.fw_utilities import get_fw_logger
 
 __author__ = 'Anubhav Jain'
@@ -49,6 +50,10 @@ def do_ping(launchpad, launch_id):
 
 
 def ping_launch(launchpad, launch_id, stop_event, master_thread):
+    if isinstance(launchpad, OfflineLaunchPad):
+        # one connection per thread
+        launchpad = launchpad.copy()
+
     while not stop_event.is_set() and master_thread.isAlive():
         do_ping(launchpad, launch_id)
         stop_event.wait(PING_TIME_SECS)

--- a/fireworks/tests/mongo_tests.py
+++ b/fireworks/tests/mongo_tests.py
@@ -639,7 +639,11 @@ class SQLiteTests(MongoTests):
             n = len(c.execute('SELECT * FROM {}'.format(name)).fetchall())
         return n
 
+    def test_basic_fw_offline(self):
+        pass
 
+    def test_offline_fw_passinfo(self):
+        pass
 
 
 if __name__ == "__main__":

--- a/fireworks/tests/mongo_tests.py
+++ b/fireworks/tests/mongo_tests.py
@@ -40,10 +40,10 @@ MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 NCORES_PARALLEL_TEST = 4
 
 def random_launch(lp_creds):
-        lp = LaunchPad.from_dict(lp_creds)
-        while lp.run_exists(None):
-            launch_rocket(lp)
-            time.sleep(random.random()/3+0.1)
+    lp = LaunchPad.from_dict(lp_creds)
+    while lp.run_exists(None):
+        launch_rocket(lp)
+        time.sleep(random.random()/3+0.1)
 
 def throw_error(msg):
     raise ValueError(msg)

--- a/fireworks/tests/mongo_tests.py
+++ b/fireworks/tests/mongo_tests.py
@@ -14,6 +14,8 @@ from fireworks import explicit_serialize, FWAction
 from fireworks.core.firework import Firework, Workflow, FiretaskBase
 from fireworks.core.fworker import FWorker
 from fireworks.core.launchpad import LaunchPad, WFLock
+from fireworks.core.offline_launchpad import OfflineLaunchPad
+
 from fireworks.core.rocket_launcher import launch_rocket, rapidfire
 from fireworks.features.background_task import BackgroundTask
 from fireworks.queue.queue_launcher import setup_offline_job
@@ -595,6 +597,35 @@ class MongoTests(unittest.TestCase):
         launch_rocket(self.lp, self.fworker)
         workflow_results=s.get_workflow_summary(time_field="updated_on")
         self.assertEqual((workflow_results[0]["_id"], workflow_results[0]["count"]), ("COMPLETED", 3))
+
+
+class SQLiteTests(MongoTests):
+    @classmethod
+    def setUpClass(cls):
+        cls.fworker = FWorker()
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        self.lp = OfflineLaunchPad('db.sqlite')
+        self.lp.reset()
+        self.old_wd = os.getcwd()
+
+    def tearDown(self):
+        os.remove('db.sqlite')
+        if os.path.exists(os.path.join('FW.json')):
+            os.remove('FW.json')
+        if os.path.exists(os.path.join('FW_offline.json')):
+            os.remove('FW_offline.json')
+        if os.path.exists(os.path.join('FW_ping.json')):
+            os.remove('FW_ping.json')
+        os.chdir(self.old_wd)
+        for i in glob.glob(os.path.join(MODULE_DIR, 'launcher*')):
+            shutil.rmtree(i)
+
+
 
 
 if __name__ == "__main__":

--- a/fireworks/tests/test_offline_launchpad.py
+++ b/fireworks/tests/test_offline_launchpad.py
@@ -8,6 +8,17 @@ def assert_fireworks_equal(a, b):
     assert a.to_dict() == b.to_dict()
 
 
+def assert_workflows_equal(a, b):
+    d_a, d_b = a.to_dict(), b.to_dict()
+    for k in ['created_on', 'updated_on']:
+        val_a, val_b = d_a.pop(k), d_b.pop(k)
+    fws_a, fws_b = d_a.pop('fws'), d_b.pop('fws')
+    for fw_a, fw_b in zip(sorted(fws_a, key=lambda x: x['fw_id']),
+                          sorted(fws_b, key=lambda x: x['fw_id'])):
+        assert fw_a == fw_b
+    assert d_a == d_b
+
+
 @pytest.fixture
 def lp():
     lp = fw.OfflineLaunchPad()
@@ -65,3 +76,10 @@ def test_get_fw_by_id(lp, workflow):
 
     assert_fireworks_equal(firework1, fw1)
     assert_fireworks_equal(firework2, fw2)
+
+def test_get_wf_by_fw_id(lp, workflow):
+    lp.add_wf(workflow)
+
+    work = lp.get_wf_by_fw_id(workflow.fws[0].fw_id)
+
+    assert_workflows_equal(work, workflow)

--- a/fireworks/tests/test_offline_launchpad.py
+++ b/fireworks/tests/test_offline_launchpad.py
@@ -4,6 +4,14 @@ import fireworks as fw
 from fireworks.user_objects.firetasks.script_task import ScriptTask
 
 
+def assert_datetime_almost_equal(a, b, tol=0.001):
+    # checks time diff between two is less than tol *seconds*
+    # sometimes tzinfo is set, so just strip that out
+    a = a.replace(tzinfo=None)
+    b = b.replace(tzinfo=None)
+    assert abs((a - b).total_seconds()) < tol
+
+
 def assert_fireworks_equal(a, b):
     assert a.to_dict() == b.to_dict()
 
@@ -12,6 +20,7 @@ def assert_workflows_equal(a, b):
     d_a, d_b = a.to_dict(), b.to_dict()
     for k in ['created_on', 'updated_on']:
         val_a, val_b = d_a.pop(k), d_b.pop(k)
+        assert_datetime_almost_equal(val_a, val_b)
     fws_a, fws_b = d_a.pop('fws'), d_b.pop('fws')
     for fw_a, fw_b in zip(sorted(fws_a, key=lambda x: x['fw_id']),
                           sorted(fws_b, key=lambda x: x['fw_id'])):

--- a/fireworks/tests/test_offline_launchpad.py
+++ b/fireworks/tests/test_offline_launchpad.py
@@ -158,3 +158,15 @@ def test_checkout_exhaustion(lp, workflow):
 
     assert val1 is None
     assert val2 is None
+
+
+def test_get_launch(lp, workflow):
+    lp.add_wf(workflow)
+
+    firework, launch_id = lp.checkout_fw(fw.FWorker(), './here/')
+
+    launch = lp.get_launch_by_id(launch_id)
+
+    assert isinstance(launch, fw.Launch)
+    assert launch.fw_id == firework.fw_id
+    assert launch.launch_dir == './here/'

--- a/fireworks/tests/test_offline_launchpad.py
+++ b/fireworks/tests/test_offline_launchpad.py
@@ -1,0 +1,29 @@
+import fireworks as fw
+
+def test_get_new_launch_id():
+    lp = fw.OfflineLaunchPad()
+    lp.reset()
+
+    assert lp.get_new_launch_id() == 1
+    assert lp.get_new_launch_id() == 2
+    assert lp.get_new_launch_id() == 3
+
+    lp.reset()
+
+    assert lp.get_new_launch_id() == 1
+    assert lp.get_new_launch_id() == 2
+    assert lp.get_new_launch_id() == 3
+
+def test_get_new_fw_id():
+    lp = fw.OfflineLaunchPad()
+    lp.reset()
+
+    assert lp.get_new_fw_id() == 1
+    assert lp.get_new_fw_id() == 2
+    assert lp.get_new_fw_id() == 3
+
+    lp.reset()
+
+    assert lp.get_new_fw_id() == 1
+    assert lp.get_new_fw_id() == 2
+    assert lp.get_new_fw_id() == 3

--- a/fireworks/tests/test_offline_launchpad.py
+++ b/fireworks/tests/test_offline_launchpad.py
@@ -1,9 +1,29 @@
+import pytest
+
 import fireworks as fw
+from fireworks.user_objects.firetasks.script_task import ScriptTask
 
-def test_get_new_launch_id():
+
+def assert_fireworks_equal(a, b):
+    assert a.to_dict() == b.to_dict()
+
+
+@pytest.fixture
+def lp():
     lp = fw.OfflineLaunchPad()
     lp.reset()
 
+    return lp
+
+@pytest.fixture
+def workflow():
+    firework1 = fw.Firework(ScriptTask.from_str("echo '1'"))
+    firework2 = fw.Firework(ScriptTask.from_str("echo '1'"),
+                            parents=firework1)
+    return fw.Workflow([firework1, firework2])
+
+
+def test_get_new_launch_id(lp):
     assert lp.get_new_launch_id() == 1
     assert lp.get_new_launch_id() == 2
     assert lp.get_new_launch_id() == 3
@@ -14,10 +34,7 @@ def test_get_new_launch_id():
     assert lp.get_new_launch_id() == 2
     assert lp.get_new_launch_id() == 3
 
-def test_get_new_fw_id():
-    lp = fw.OfflineLaunchPad()
-    lp.reset()
-
+def test_get_new_fw_id(lp):
     assert lp.get_new_fw_id() == 1
     assert lp.get_new_fw_id() == 2
     assert lp.get_new_fw_id() == 3
@@ -27,3 +44,24 @@ def test_get_new_fw_id():
     assert lp.get_new_fw_id() == 1
     assert lp.get_new_fw_id() == 2
     assert lp.get_new_fw_id() == 3
+
+
+def test_not_run_exists(lp):
+    assert not lp.run_exists()
+
+
+def test_run_exists(lp, workflow):
+    lp.add_wf(workflow)
+
+    assert lp.run_exists()
+
+def test_get_fw_by_id(lp, workflow):
+    lp.add_wf(workflow)
+
+    fw1, fw2 = workflow.fws
+
+    firework1 = lp.get_fw_by_id(fw1.fw_id)
+    firework2 = lp.get_fw_by_id(fw2.fw_id)
+
+    assert_fireworks_equal(firework1, fw1)
+    assert_fireworks_equal(firework2, fw2)

--- a/fireworks/tests/test_offline_launchpad.py
+++ b/fireworks/tests/test_offline_launchpad.py
@@ -38,9 +38,10 @@ def lp():
 @pytest.fixture
 def workflow():
     firework1 = fw.Firework(ScriptTask.from_str("echo '1'"))
-    firework2 = fw.Firework(ScriptTask.from_str("echo '1'"),
-                            parents=firework1)
-    return fw.Workflow([firework1, firework2])
+    firework2 = fw.Firework(ScriptTask.from_str("echo '2'"))
+    firework3 = fw.Firework(ScriptTask.from_str("echo '3'"),
+                            parents=[firework1, firework2])
+    return fw.Workflow([firework1, firework2, firework3])
 
 
 def test_get_new_launch_id(lp):
@@ -78,7 +79,7 @@ def test_run_exists(lp, workflow):
 def test_get_fw_by_id(lp, workflow):
     lp.add_wf(workflow)
 
-    fw1, fw2 = workflow.fws
+    fw1, fw2, _ = workflow.fws
 
     firework1 = lp.get_fw_by_id(fw1.fw_id)
     firework2 = lp.get_fw_by_id(fw2.fw_id)
@@ -92,3 +93,41 @@ def test_get_wf_by_fw_id(lp, workflow):
     work = lp.get_wf_by_fw_id(workflow.fws[0].fw_id)
 
     assert_workflows_equal(work, workflow)
+
+def test_checkout_fw(lp, workflow):
+    lp.add_wf(workflow)
+
+    firework, _ = lp.checkout_fw(fw.FWorker(), launch_dir='.')
+
+    assert isinstance(firework, fw.Firework)
+
+def test_checkout_fw_specific(lp, workflow):
+    lp.add_wf(workflow)
+
+    fw_to_get = workflow.fws[0]
+
+    firework, _ = lp.checkout_fw(fw.FWorker(), launch_dir='.',
+                                 fw_id=fw_to_get.fw_id)
+
+    # fireworks aren't strictly equal any more as checking out has modified it
+    # instead...
+    assert firework.fw_id == fw_to_get.fw_id
+    assert firework.spec == fw_to_get.spec
+
+def test_checkout_multiple(lp, workflow):
+    lp.add_wf(workflow)
+
+    ref_fw1, ref_fw2, ref_fw3 = workflow.fws
+
+    fw1, _ = lp.checkout_fw(fw.FWorker(), '.')
+    fw2, _ = lp.checkout_fw(fw.FWorker(), '.')
+
+    print(fw1.fw_id, fw2.fw_id)
+
+    print(ref_fw1.fw_id, ref_fw2.fw_id)
+
+    # at this point, we should have checked out ref_fw1 and ref_fw2
+    # ref_fw3 has unsatisfied dependencies
+    for ref_firework in [ref_fw1, ref_fw2]:
+        assert any(firework.fw_id == ref_firework.fw_id
+                   for firework in (fw1, fw2))

--- a/fireworks/tests/test_offline_launchpad.py
+++ b/fireworks/tests/test_offline_launchpad.py
@@ -170,3 +170,13 @@ def test_get_launch(lp, workflow):
     assert isinstance(launch, fw.Launch)
     assert launch.fw_id == firework.fw_id
     assert launch.launch_dir == './here/'
+
+
+def test_change_launch_idr(lp, workflow):
+    lp.add_wf(workflow)
+
+    firework, launch_id = lp.checkout_fw(fw.FWorker(), './here/')
+
+    lp.change_launch_dir(launch_id, './newplace')
+
+    assert lp.get_launch_by_id(launch_id).launch_dir == './newplace'

--- a/fireworks/tests/test_offline_launchpad.py
+++ b/fireworks/tests/test_offline_launchpad.py
@@ -31,7 +31,7 @@ def assert_workflows_equal(a, b):
 
 @pytest.fixture
 def lp():
-    lp = fw.OfflineLaunchPad()
+    lp = fw.OfflineLaunchPad(address=':memory:')
     lp.reset()
 
     return lp

--- a/fireworks/tests/test_offline_launchpad.py
+++ b/fireworks/tests/test_offline_launchpad.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 import fireworks as fw
@@ -28,10 +29,18 @@ def assert_workflows_equal(a, b):
         assert fw_a == fw_b
     assert d_a == d_b
 
+@pytest.fixture
+def in_tmpdir(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        yield
+    finally:
+        os.chdir(cwd)
 
 @pytest.fixture
-def lp():
-    lp = fw.OfflineLaunchPad(address=':memory:')
+def lp(in_tmpdir):
+    lp = fw.OfflineLaunchPad(address='db.sqlite')
     lp.reset()
 
     return lp

--- a/fireworks/tests/test_offline_launchpad.py
+++ b/fireworks/tests/test_offline_launchpad.py
@@ -2,6 +2,7 @@ import pytest
 
 import fireworks as fw
 from fireworks.user_objects.firetasks.script_task import ScriptTask
+from fireworks.core.rocket_launcher import launch_rocket
 
 
 def assert_datetime_almost_equal(a, b, tol=0.001):
@@ -180,3 +181,11 @@ def test_change_launch_idr(lp, workflow):
     lp.change_launch_dir(launch_id, './newplace')
 
     assert lp.get_launch_by_id(launch_id).launch_dir == './newplace'
+
+
+def test_launch_rocket(lp, workflow):
+    lp.add_wf(workflow)
+
+    val = launch_rocket(lp)
+
+    assert val is True


### PR DESCRIPTION
Adds an OfflineLaunchPad class, which has a sqlite3 backend.  This isn't to replace LaunchPad, but just adds a different storage medium.  This hasn't modified anything outside of the LaunchPad, (so far).  The only point of grief I've found so far is that `FWorker.query` is hardcoded to be mongodb syntax.  Oh and `LaunchPad` methods take mongodb queries all over the show, this won't work with a sqlite backend.

Currently creating a Workflow, submitting it, and running it with `rocket_launch` works, so this kind of works?  All sorts of corner cases don't work yet....

ping @shyamd 