### PR TITLE
small updates

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -33,6 +33,8 @@ from fireworks.fw_config import LAUNCHPAD_LOC, SORT_FWS, RESERVATION_EXPIRATION_
 from fireworks.utilities.fw_serializers import FWSerializable, reconstitute_dates
 from fireworks.core.firework import Firework, Launch, Workflow, FWAction, Tracker
 from fireworks.utilities.fw_utilities import get_fw_logger
+from fireworks.utilities.fw_serializers import recursive_dict
+
 
 __author__ = 'Anubhav Jain'
 __copyright__ = 'Copyright 2013, The Materials Project'
@@ -1447,7 +1449,7 @@ class LaunchPad(FWSerializable):
         if recover_launch is not None:
             recovery = self.get_recovery(fw_id, recover_launch)
             recovery.update({'_mode': recover_mode})
-            set_spec = {'$set': {'spec._recovery': recovery}}
+            set_spec = recursive_dict({'$set': {'spec._recovery': recovery}})
             if recover_mode == 'prev_dir':
                 prev_dir = self.get_launch_by_id(recovery.get('_launch_id')).launch_dir
                 set_spec['$set']['spec._launch_dir'] = prev_dir

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -490,8 +490,15 @@ def cancel_qid(args):
 
 
 def set_priority(args):
+    wf_mode = args.wf
     lp = get_lp(args)
-    fw_ids = parse_helper(lp, args)
+    fw_ids = parse_helper(lp, args, wf_mode=wf_mode)
+    if wf_mode:
+        all_fw_ids = set()
+        for fw_id in fw_ids:
+            wf = lp.get_wf_by_fw_id_lzyfw(fw_id)
+            all_fw_ids.update(wf.id_fw.keys())
+        fw_ids = list(all_fw_ids)
     for f in fw_ids:
         lp.set_priority(f, args.priority)
         lp.m_logger.debug("Processed fw_id {}".format(f))
@@ -1011,6 +1018,8 @@ def lpad():
                                                     "Password or positive response to input prompt "
                                                     "required when modifying more than {} "
                                                     "entries.".format(PW_CHECK_NUM))
+    priority_parser.add_argument('-wf', action='store_true',
+                                 help='the priority will be set for all the fireworks of the matching workflows')
     priority_parser.set_defaults(func=set_priority)
 
     parser.add_argument('-l', '--launchpad_file', help='path to LaunchPad file containing '


### PR DESCRIPTION
This PR contains two modifications.

The first is a fix for a minor problem that I have ancountered in ``rerun_fw`` in combination with the ``recover_launch`` option. The ``recover_launch`` dictionary is coming from the ``checkpoint`` keyword in the Launch history. This can contain the serialized version of an MSONable object. This gets deserialized while loading, but when doing the
```python
self.fireworks.find_one_and_update({"fw_id": fw_id}, set_spec)
```
it is not serialized and the update of a dictionary containing this object fails. I added a ``recursive_dict`` that solves the problem and should be harmless for all the other cases. 

I just have the doubt if this should instead be done inside ``get_recovery``. The API of that method is not really explicit about what should be its output.


The second point is the addition of a ``-wf`` option for the ``set_priority`` command in ``lpad``. I sometimes want to set a priority for a whole workflow and this seemed a functionality that could be useful for the generic user.