### PR TITLE
fix -t option in lpad get_wflows

### DIFF
--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -321,17 +321,17 @@ def get_wfs(args):
             d["name"] += "--%d" % i
             wfs.append(d)
 
-    if len(wfs) == 1:
-        wfs = wfs[0]
-
     if args.table:
-        headers = list(wfs[0].keys())
-        from prettytable import PrettyTable
-        t = PrettyTable(headers)
-        for d in wfs:
-            t.add_row([d.get(k) for k in headers])
-        print(t)
+        if wfs:
+            headers = list(wfs[0].keys())
+            from prettytable import PrettyTable
+            t = PrettyTable(headers)
+            for d in wfs:
+                t.add_row([d.get(k) for k in headers])
+            print(t)
     else:
+        if len(wfs) == 1:
+            wfs = wfs[0]
         print(args.output(wfs))
 
 

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -865,6 +865,10 @@ def lpad():
     pause_fw_parser.add_argument(*state_args, **state_kwargs)
     pause_fw_parser.add_argument(*query_args, **query_kwargs)
     pause_fw_parser.add_argument(*launches_mode_args, **launches_mode_kwargs)
+    pause_fw_parser.add_argument('--password', help="Today's date, e.g. 2012-02-25. "
+                                                    "Password or positive response to input "
+                                                    "prompt required when modifying more than {} "
+                                                    "entries.".format(PW_CHECK_NUM))
     pause_fw_parser.set_defaults(func=pause_fws)
 
 


### PR DESCRIPTION
Not sure if it is really used, but currently the `-t` option for `lpad get_wflows` fails in case of 1 or 0 workflows listed