### PR TITLE
Load according to server scheme (https or http)

### DIFF
--- a/fireworks/flask_site/templates/wf_details.html
+++ b/fireworks/flask_site/templates/wf_details.html
@@ -6,7 +6,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/jquery.jsonview.css') }}" />
 <link href="{{ url_for('static', filename='font-awesome-4.0.3/css/font-awesome.css')}}" rel="stylesheet" type="text/css" />
 <link href="{{ url_for('static', filename='css/cytoscape.js-panzoom.css')}}" rel="stylesheet" type="text/css" />
-<script type="text/javascript" src="http://code.jquery.com/jquery.min.js"></script>
+<script type="text/javascript" src="//code.jquery.com/jquery.min.js"></script>
 <script type="text/javascript" src="{{ url_for('static', filename='js/jquery.jsonview.js') }}"></script>
 <script type="text/javascript" src="{{ url_for('static', filename='js/cytoscape.min.js') }}"></script>
 <script type="text/javascript" src="{{ url_for('static', filename='js/dagre.js') }}"></script>


### PR DESCRIPTION
Browsers like Firefox refuse to load files over http if the host page is served over https.