### PR TITLE
Feature request - adding state of the FW for _pass_job_info

### DIFF
--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -445,7 +445,7 @@ class Rocket:
 
         if my_spec.get("_pass_job_info"):
             job_info = list(my_spec.get("_job_info", []))
-            this_job_info = {"fw_id": m_fw.fw_id, "name": m_fw.name, "launch_dir": launch_dir}
+            this_job_info = {"fw_id": m_fw.fw_id, "name": m_fw.name, "launch_dir": launch_dir, "state":m_fw.state}
             if this_job_info not in job_info:
                 job_info.append(this_job_info)
             fwaction.mod_spec.append({"_push_all": {"_job_info": job_info}})


### PR DESCRIPTION
For the special spec argument "_pass_job_info", it would be useful to get the state of the parent FWs. Normally, the state of a parent should be "COMPLETED", however, if we also have the special spec argument "_allow_fizzled_parents" this is not always the case. It would be easier to pass the job info for this situation than to load it from the collection during a FW.