### PR TITLE
Allow binary files in filepad

### DIFF
--- a/fireworks/user_objects/firetasks/filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/filepad_tasks.py
@@ -77,8 +77,11 @@ class GetFilesTask(FiretaskBase):
         for i, l in enumerate(self["identifiers"]):
             file_contents, doc = fpad.get_file(identifier=l)
             file_name = new_file_names[i] if new_file_names else doc["original_file_name"]
-            with open(os.path.join(dest_dir, file_name), "w") as f:
-                f.write(file_contents.decode())
+            # Instead of worrying about encoding, just write binary data.
+            # Handling encoding correctly for text files is no longer
+            # a responsibility of Fireworks here.
+            with open(os.path.join(dest_dir, file_name), "wb") as f:
+                f.write(file_contents)
 
 class GetFilesByQueryTask(FiretaskBase):
     """

--- a/fireworks/utilities/filepad.py
+++ b/fireworks/utilities/filepad.py
@@ -111,7 +111,7 @@ class FilePad(MSONable):
                      "original_file_path": path,
                      "metadata": metadata,
                      "compressed": compress}
-        with open(path, "r") as f:
+        with open(path, "rb") as f:
             contents = f.read()
             return self._insert_contents(contents, identifier, root_data, compress)
 
@@ -242,7 +242,7 @@ class FilePad(MSONable):
 
     def _insert_to_gridfs(self, contents, compress):
         if compress:
-            contents = zlib.compress(contents.encode(), compress)
+            contents = zlib.compress(contents, compress)
         # insert to gridfs
         return str(self.gridfs.put(contents))
 
@@ -279,7 +279,7 @@ class FilePad(MSONable):
             return None, None
         old_gfs_id = doc["gfs_id"]
         self.gridfs.delete(old_gfs_id)
-        gfs_id = self._insert_to_gridfs(open(path, "r").read(), compress)
+        gfs_id = self._insert_to_gridfs(open(path, "rb").read(), compress)
         doc["gfs_id"] = gfs_id
         doc["compressed"] = compress
         return old_gfs_id, gfs_id


### PR DESCRIPTION
So far, it has only been possible to store text files in the filepad. Trying to store binary files threw an error. This simple modification stores all files as binary in the filepad. However, the filepad behavior would change in such a way that the responsibility of correctly encoding / decoding text files is passed on to the user.