### PR TITLE
_files_in from an arbitrary number of merging workflow branches

### DIFF
--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -462,8 +462,10 @@ class Rocket:
             for k, v in my_spec.get("_files_out").items():
                 files = glob.glob(os.path.join(launch_dir, v))
                 if files:
-                    filepaths[k] = sorted(files)[-1]
-            fwaction.update_spec["_files_prev"] = filepaths
+                    filepath = sorted(files)[-1]
+                    fwaction.mod_spec.append( {
+                      "_set": {"_files_prev->{:s}".format(k): filepath }
+                    } )
         elif "_files_prev" in my_spec:
             # This ensures that _files_prev are not passed from Firework to
             # Firework. We do not want output files from fw1 to be used by fw3


### PR DESCRIPTION
Use mod_spec instead of update_spec to pass on out-/infiles along Fireworks. 

That allows for files to come from several merging branches of a workflow as in
![image](https://user-images.githubusercontent.com/1868344/62634254-dd606c80-b935-11e9-924f-0acc7803fe84.png)
as long as they are labeled differently.

It seemed to me that with the previous "update_spec" utilization, only (a set of) _files_out from one branch were passed onto the child firework, depending on which branch executed last. 