### PR TITLE
Recover offline revisited

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -1729,12 +1729,18 @@ class LaunchPad(FWSerializable):
 
             # When calling ping_launch above, the local m_launch object and its
             # state history are not affected.
+            # Thus, get the updated launch again from database:
+            m_launch = self.get_launch_by_id(launch_id)
 
             if 'started_on' in offline_data:
                 m_launch.state = 'RUNNING'
+                # The folllowing seems to touch not only the current, but all
+                # "RUNNING" history entries. Is that supposed to work like this?
                 for s in m_launch.state_history:
                     if s['state'] == 'RUNNING':
                         s['created_on'] = reconstitute_dates(offline_data['started_on'])
+                        # Why use reconstitute_dates here, but not in
+                        # Launch.touch_history ?
                 l = self.launches.find_one_and_replace({'launch_id': m_launch.launch_id},
                                                        m_launch.to_db_dict(), upsert=True)
                 fw_id = l['fw_id']

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -1706,7 +1706,7 @@ class LaunchPad(FWSerializable):
                 # and update in launches collection together with tracked files.
                 # Also set checkpoint information if found in FW_offline.json:
                 self.ping_launch(launch_id, ptime=ping_dict['ping_time'],
-                  checkpoint=checkoint)
+                  checkpoint=checkpoint)
             elif checkpoint:
                 # If no FW_ping.json exists, state must be other than RUNNING?
                 #

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -1712,7 +1712,7 @@ class LaunchPad(FWSerializable):
                 #
                 # In this case, set update_on in state_history to current datetime
                 # and append checkpoint information if found in FW_offline.json:
-                m_launch.touch_history(checkpoint=offline_data['checkpoint'])
+                m_launch.touch_history(checkpoint=checkpoint)
                 self.launches.find_one_and_replace(
                   {'launch_id': m_launch.launch_id},
                   m_launch.to_db_dict(), upsert=True)


### PR DESCRIPTION
This pull request addresses two related issues discussed at the [google group](https://groups.google.com/d/msg/fireworkflows/oimFmE5tZ4E/xq-uHIxVCAAJ):

1. When fizzling a "lost run", check whether it has been an offline run. If so, forget offline run (i.e. mark as "deprecated")
2. When recovering offline runs, always use the ping time found in "FW_ping.json" as the "updated_on" time in the launch's state history. Previously, subsequent touch_history commands and database updates used to always override the ping time with the current date. That led to "detect_lostruns" not being able to identify lost offline runs. 

This is a suggestion that solves those two particular issues. However, the "checkpoint" update has been moved up, now occurring either via 

a) the [ping_launch(...)](https://github.com/materialsproject/fireworks/blob/cb05763ebb6b82f543cf2e935ac778bc4d2082b4/fireworks/core/launchpad.py#L1351-L1366) call, which already offers the possibility to pass on a checkpoint, if a ping file exists, or 
b) directly via [touch_history, just as before](https://github.com/materialsproject/fireworks/blob/cb05763ebb6b82f543cf2e935ac778bc4d2082b4/fireworks/core/launchpad.py#L1708-L1711), but **only in the case of no ping file being present**. 

Afterwards, the launch is queried again in order to avoid overriding the possibly updated state history in any subsequent modification of the launches collection.

This is not a beautiful solution, rather a quick restructuring solving the two addressed issued, touching only as much code as necessary. However, there might be other issues arising. 

In the code, I left some open questions as comments. 

Best regards,

Johannes
