### PR TITLE
fix for lpad

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -444,11 +444,13 @@ class LaunchPad(FWSerializable):
         if not fw_dict:
             raise ValueError('No Firework exists with id: {}'.format(fw_id))
         # recreate launches from the launch collection
-        launches = list(self.launches.find({'launch_id': {"$in": fw_dict['launches']}}))
+        launches = list(self.launches.find({'launch_id': {"$in": fw_dict['launches']}},
+                                           sort=[("launch_id", ASCENDING)]))
         for l in launches:
             l["action"] = get_action_from_gridfs(l.get("action"), self.gridfs_fallback)
         fw_dict['launches'] = launches
-        launches = list(self.launches.find({'launch_id': {"$in": fw_dict['archived_launches']}}))
+        launches = list(self.launches.find({'launch_id': {"$in": fw_dict['archived_launches']}},
+                                           sort=[("launch_id", ASCENDING)]))
         for l in launches:
             l["action"] = get_action_from_gridfs(l.get("action"), self.gridfs_fallback)
         fw_dict['archived_launches'] = launches
@@ -1440,7 +1442,7 @@ class LaunchPad(FWSerializable):
             recover_launch ('last' or int): launch_id for last recovery, if set to
                 'last' (default), recovery will find the last available launch.
                 If it is an int, will recover that specific launch
-            recover_mode ('prev_dir' or 'copy'): flag to indicate whether to copy
+            recover_mode ('prev_dir' or 'cp'): flag to indicate whether to copy
                 or run recovery fw in previous directory
 
         Returns:

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -102,8 +102,11 @@ def parse_helper(lp, args, wf_mode=False, skip_pw=False):
 
 def get_lp(args):
     try:
-        if not args.launchpad_file and os.path.exists(os.path.join(args.config_dir, DEFAULT_LPAD_YAML)):
-            args.launchpad_file = os.path.join(args.config_dir, DEFAULT_LPAD_YAML)
+        if not args.launchpad_file:
+            if os.path.exists(os.path.join(args.config_dir, DEFAULT_LPAD_YAML)):
+                args.launchpad_file = os.path.join(args.config_dir, DEFAULT_LPAD_YAML)
+            else:
+                args.launchpad_file = LAUNCHPAD_LOC
 
         if args.launchpad_file:
             return LaunchPad.from_file(args.launchpad_file)
@@ -1046,7 +1049,7 @@ def lpad():
 
     parser.add_argument('-l', '--launchpad_file', help='path to LaunchPad file containing '
                                                        'central DB connection info',
-                        default=LAUNCHPAD_LOC)
+                        default=None)
     parser.add_argument('-c', '--config_dir',
                         help='path to a directory containing the LaunchPad file (used if -l unspecified)',
                         default=CONFIG_FILE_DIR)


### PR DESCRIPTION
I have found two potential problems related to the LaunchPad.

The first is in the `lpad` command. Since the `-l` option is assigned a default in argparse the `-c` is never taken into account. I removed the default and modified the `parse_helper` function so that it should properly consider the `-c` option as well.

The second problem concerns the fetching of the Launches from the database. 
Currently the launches are fetched in this way:
```python
list(self.launches.find({'launch_id': {"$in": fw_dict['launches']}}))
```
My understanding of how MongoDB works is that this query does not guarantee the order of the launches (and archived launches as well). This list is then passed directly to the Firework `__init__`. The incorrect order might be an issue, since in some portions of the code the last launch is accessed with `fw.launches[-1]`. e.g.
https://github.com/materialsproject/fireworks/blob/master/fireworks/core/launchpad.py#L1527
I propose to add a sorting when the launches are pulled from the DB. 
Do you agree that this is actually an issue? Would this solution work for you?