### PR TITLE
Update Google Groups references to Discourse

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 Please submit help issues to:
-https://groups.google.com/forum/#!forum/fireworkflows
+https://hackingmaterials.discourse.group/c/fireworks
 
 The Github issues is no longer used except for internal development purposes.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,4 +3,4 @@ https://hackingmaterials.discourse.group/c/fireworks
 
 The Github issues is no longer used except for internal development purposes.
 
-If you are unable to use the Google Group, you may submit an issue here, but you must **clearly** state the reason you are unable to use the Google Group in your ticket. Otherwise, your issue will be **closed** without response.
+If you are unable to use the Discourse forum, you may submit an issue here, but you must **clearly** state the reason you are unable to use the Discourse forum in your ticket. Otherwise, your issue will be **closed** without response.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We love your input! We want to make contributing to FireWorks as easy and transp
 * Becoming a maintainer
 
 ## Reporting bugs, getting help, and discussion
-At any time, feel free to start a thread on our [Google Group](https://groups.google.com/forum/#!forum/fireworkflows).
+At any time, feel free to start a thread on our [Discourse forum](https://hackingmaterials.discourse.group/c/fireworks).
 
 If you are making a bug report, incorporate as many elements of the following as possible to ensure a timely response and avoid the need for followups:
 * A quick summary and/or background
@@ -35,10 +35,10 @@ We have a few tips for writing good PRs that are accepted into the main repo:
 * Your code should have (4) spaces instead of tabs.
 * If needed, update the documentation.
 * **Write tests** for new features! Good tests are 100%, absolutely necessary for good code. We use the python `unittest` framework -- see some of the other tests in this repo for examples, or review the [Hitchhiker's guide to python](https://docs.python-guide.org/writing/tests/) for some good resources on writing good tests.
-* Understand your contributions will fall under the same license as this repo. 
+* Understand your contributions will fall under the same license as this repo.
 
-When you submit your PR, our CI service will automatically run your tests. 
+When you submit your PR, our CI service will automatically run your tests.
 We welcome good discussion on the best ways to write your code, and the comments on your PR are an excellent area for discussion.
 
 #### References
-This document was adapted from the open-source contribution guidelines for Facebook's Draft, as well as briandk's [contribution template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62). 
+This document was adapted from the open-source contribution guidelines for Facebook's Draft, as well as briandk's [contribution template](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62).

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 FireWorks stores, executes, and manages calculation workflows.
 
 - **Website (including documentation):** https://materialsproject.github.io/fireworks/
-- **Help/Support:** https://groups.google.com/forum/#!forum/fireworkflows
+- **Help/Support:** https://hackingmaterials.discourse.group/c/fireworks
 - **Source:** https://github.com/materialsproject/fireworks/

--- a/docs_rst/index.rst
+++ b/docs_rst/index.rst
@@ -259,7 +259,7 @@ Want to see something added or changed? There are many ways to make that a reali
 * Point us to areas of the code that are difficult to understand or use.
 * Contribute code! If you are interested in this option, please see our :doc:`contribution guidelines</contributing>`.
 
-Please submit questions, issues / bug reports, and all other communication through the `FireWorks Google Groups <https://groups.google.com/forum/#!forum/fireworkflows>`_.
+Please submit questions, issues / bug reports, and all other communication through the `FireWorks Discourse forum <https://hackingmaterials.discourse.group/c/fireworks>`_.
 
 Make contributions through GitHub using our `Contribution Guidelines. <https://github.com/materialsproject/fireworks/blob/master/CONTRIBUTING.md>`_
 


### PR DESCRIPTION
The FireWorks support forum is moving from Google Groups to Discourse (https://hackingmaterials.discourse.group/c/fireworks). I've updated all references to Google Groups to point to the new forum.

However, as we are not migrating old posts to the new forum, I've left in links that point to specific  Google Groups posts. Specifically, these are:

```
./fireworks/core/launchpad.py:                # see: https://groups.google.com/forum/#!topic/fireworkflows/oimFmE5tZ4E
./docs_rst/installation.rst:.. note:: We suggest that you use Python 2.7.3 or higher, especially in production. There is a `bug <https://groups.google.com/forum/#!topic/modwsgi/DW-SlIb07rE>`_ in Python 2.7.2 that could affect FireWorks (although we haven't seen any problems yet). As of FireWorks v0.7, Python 3.3 and higher should also work.
``` 

Once merged, the docs should be regenerated to reflect the updates. 