### PR TITLE
update common adapter for SLURM

### DIFF
--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -71,12 +71,10 @@ class CommonAdapter(QueueAdapterBase):
 
     def _parse_jobid(self, output_str):
         if self.q_type == "SLURM":
-            if isinstance(output_str, bytes):  # Py3 compatibility
-                output_str = output_str.decode('utf-8')
-            for l in output_str.split("\n"):
-                if l.startswith("Submitted batch job"):
-                    return int(l.split()[-1])
-        if self.q_type == "LoadLeveler":
+            # The line can contain more text after the id.
+            # Match after the standard "Submitted batch job" string
+            re_string = r"Submitted batch job\s+(\d+)"
+        elif self.q_type == "LoadLeveler":
             # Load Leveler: "llsubmit: The job "abc.123" has been submitted"
             re_string = r"The job \"(.*?)\" has been submitted"
         elif self.q_type == "Cobalt":

--- a/fireworks/user_objects/queue_adapters/tests/test_common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/tests/test_common_adapter.py
@@ -121,7 +121,7 @@ JobId   User    Queue     Jobname  Nodes  Procs  Mode    WallTime  State    RunT
         sbatch_output = """
 SOME PREAMBLE
 Submitted batch job 1234"""
-        self.assertEqual(p._parse_jobid(sbatch_output), 1234)
+        self.assertEqual(p._parse_jobid(sbatch_output), '1234')
         p = CommonAdapter(
             q_type="Cobalt",
             q_name="hello",


### PR DESCRIPTION
On one of our clusters when submitting a job we get the message "Submitted batch job xxxx on cluster name_of_the_cluster" instead of the standard message "Submitted batch job xxxxx" , leading to a failure in parsing the id. The PR fixes this case.

**N.B.** the current modification changes the behavior for SLURM: up to now (only for SLURM!)  `_parse_jobid` returned an int, while now it will return a string, as for all the other queue managers. This does not seem to have any effect, since the id is eventually converted back to a string before storing it: 
https://github.com/materialsproject/fireworks/blob/master/fireworks/core/firework.py#L456

Notice however that, even without this modification, the docstring for `submit_to_queue` is inconsistent, since it sometimes returns a string and sometimes an integer. This should probably be fixed as well.