### PR TITLE
Authentication from external sources

### DIFF
--- a/docs_rst/security_tutorial.rst
+++ b/docs_rst/security_tutorial.rst
@@ -78,10 +78,10 @@ If the MongoDB server is configured with TLS/SSL launchpad file
     authsource: <string> # alternative authentication database (optional)
     authmechanism: <string> # alternative authentication mechanism (optional)
 
-.. note:: If ``ssl`` is ``false`` or omitted then all remaining TLS/SSL settings **must** be omitted. If ``ssl`` is ``true`` then the connection will be encrypted and the remaining TLS/SSL settings are optional, depending on the specific server policies.
+.. note:: If ``ssl`` is ``false`` or omitted then all remaining TLS/SSL settings **must** be omitted. If ``ssl`` is ``true`` then the connection will be encrypted, ``ssl_ca_certs`` must be set and the remaining TLS/SSL settings are optional, depending on the specific server policies.
 
-.. note:: If ``ssl_certfile`` is set and ``ssl_keyfile`` is not set then the file specified by ``ssl_certfile`` must contain the private key
+.. note:: If ``ssl_certfile`` is set and ``ssl_keyfile`` is not set then the file specified by ``ssl_certfile`` must contain the private key.
 
-.. note:: If your private key is encrypted and  ``ssl_pem_passphrase`` is not set then **lpad**, **rlaunch** and **qlaunch** will prompt for the passphase.
+.. note:: If the private key is encrypted and  ``ssl_pem_passphrase`` is not set then **lpad**, **rlaunch** and **qlaunch** will prompt for the passphase.
 
-.. note:: If ``authmechanism`` is ``MONGODB-X509`` then ``authsource`` must be set to ``$external`` and ``username`` and ``password`` must not be set.
+.. note:: If ``authmechanism`` is ``MONGODB-X509`` then ``authsource`` must be set to ``$external``, and ``username`` and ``password`` must not be set.

--- a/docs_rst/security_tutorial.rst
+++ b/docs_rst/security_tutorial.rst
@@ -71,9 +71,17 @@ If the MongoDB server is configured with TLS/SSL launchpad file
 ``my_launchpad.yaml`` (or whatever launchpad file is specified after the ``-l`` option or in the configuration file) has to include further information in the following lines::
 
     ssl: <bool> # whether to use TLS/SSL for connection to MongoDB, default: false
-    ssl_ca_certs: <path to the CA certificate to be used for connection>
-    ssl_certfile: <path to the client certificate to be used for connection>
-    ssl_keyfile: <path to the client private key (optional)>
-    ssl_pem_passphrase: <passphrase for the client private key (optional)>
+    ssl_ca_certs: <string> # path to the CA certificate to be used for connection
+    ssl_certfile: <string> # path to the client certificate (optional)
+    ssl_keyfile: <string> # path to the client private key (optional)
+    ssl_pem_passphrase: <string> # passphrase for the client private key (optional)
+    authsource: <string> # alternative authentication database (optional)
+    authmechanism: <string> # alternative authentication mechanism (optional)
 
 .. note:: If ``ssl`` is ``false`` or omitted then all remaining TLS/SSL settings **must** be omitted. If ``ssl`` is ``true`` then the connection will be encrypted and the remaining TLS/SSL settings are optional, depending on the specific server policies.
+
+.. note:: If ``ssl_certfile`` is set and ``ssl_keyfile`` is not set then the file specified by ``ssl_certfile`` must contain the private key
+
+.. note:: If your private key is encrypted and  ``ssl_pem_passphrase`` is not set then **lpad**, **rlaunch** and **qlaunch** will prompt for the passphase.
+
+.. note:: If ``authmechanism`` is ``MONGODB-X509`` then ``authsource`` must be set to ``$external`` and ``username`` and ``password`` must not be set.

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -116,7 +116,7 @@ class LaunchPad(FWSerializable):
     def __init__(self, host=None, port=None, name=None, username=None, password=None,
                  logdir=None, strm_lvl=None, user_indices=None, wf_user_indices=None, ssl=False,
                  ssl_ca_certs=None, ssl_certfile=None, ssl_keyfile=None, ssl_pem_passphrase=None,
-                 authsource=None, uri_mode=False):
+                 authsource=None, authmechanism=None, uri_mode=False):
         """
         Args:
             host (str): hostname. If uri_mode is True, a MongoDB connection string URI
@@ -135,7 +135,9 @@ class LaunchPad(FWSerializable):
             ssl_certfile (str): path to the client certificate to be used for mongodb connection
             ssl_keyfile (str): path to the client private key
             ssl_pem_passphrase (str): passphrase for the client private key
-            authsource (str): authsource parameter for MongoDB authentication; defaults to "name" (i.e., db name) if
+            authsource (str): authSource parameter for MongoDB authentication; defaults to "name" (i.e., db name) if
+                not set
+            authmechanism (str): authMechanism parameter for MongoDB authentication; defaults to 'DEFAULT' if
                 not set
             uri_mode (bool): if set True, all Mongo connection parameters occur through a MongoDB URI string (set as
                 the host).
@@ -152,6 +154,7 @@ class LaunchPad(FWSerializable):
         self.ssl_keyfile = ssl_keyfile
         self.ssl_pem_passphrase = ssl_pem_passphrase
         self.authsource = authsource or self.name
+        self.authmechanism = authmechanism
         self.uri_mode = uri_mode
 
         # set up logger
@@ -176,7 +179,8 @@ class LaunchPad(FWSerializable):
                                           socketTimeoutMS=MONGO_SOCKET_TIMEOUT_MS,
                                           username=self.username,
                                           password=self.password,
-                                          authsource=self.authsource)
+                                          authSource=self.authsource,
+                                          authMechanism=self.authmechanism)
             self.db = self.connection[self.name]
 
         self.fireworks = self.db.fireworks
@@ -212,6 +216,7 @@ class LaunchPad(FWSerializable):
             'ssl_keyfile': self.ssl_keyfile,
             'ssl_pem_passphrase': self.ssl_pem_passphrase,
             'authsource': self.authsource,
+            'authmechanism': self.authmechanism,
             'uri_mode': self.uri_mode}
 
     def update_spec(self, fw_ids, spec_document, mongo=False):
@@ -256,11 +261,12 @@ class LaunchPad(FWSerializable):
         ssl_keyfile = d.get('ssl_keyfile', None)
         ssl_pem_passphrase = d.get('ssl_pem_passphrase', None)
         authsource = d.get('authsource', None)
+        authmechanism = d.get('authmechanism', None)
         uri_mode = d.get('uri_mode', False)
         return LaunchPad(d['host'], port, name, username, password,
                          logdir, strm_lvl, user_indices, wf_user_indices, ssl,
                          ssl_ca_certs, ssl_certfile, ssl_keyfile, ssl_pem_passphrase,
-                         authsource, uri_mode)
+                         authsource, authmechanism, uri_mode)
 
     @classmethod
     def auto_load(cls):


### PR DESCRIPTION
MongoDB supports external authentication mechanisms (x509 certificates, LDAP, Kerberos token) instead of internal username/password credentials. To enable them in FireWorks the ``authmechanism`` keyword has to be added to the LaunchPad object. This branch enables this feature and has been tested with x509 CA-signed certificates. The documentation is extended accordingly. LDAP, Kerberos and other external methods have not been tested.