### PR TITLE
avoid checking the number of jobs in the queue if not needed

### DIFF
--- a/fireworks/queue/queue_launcher.py
+++ b/fireworks/queue/queue_launcher.py
@@ -169,7 +169,8 @@ def rapidfire(launchpad, fworker, qadapter, launch_dir='.', nlaunches=0, njobs_q
         qadapter (QueueAdapterBase)
         launch_dir (str): directory where we want to write the blocks
         nlaunches (int): total number of launches desired; "infinite" for loop, 0 for one round
-        njobs_queue (int): stops submitting jobs when njobs_queue jobs are in the queue, 0 for no limit
+        njobs_queue (int): stops submitting jobs when njobs_queue jobs are in the queue, 0 for no limit.
+            If 0 skips the check on the number of jobs in the queue.
         njobs_block (int): automatically write a new block when njobs_block jobs are in a single block
         sleep_time (int): secs to sleep between rapidfire loop iterations
         reserve (bool): Whether to queue in reservation mode
@@ -202,8 +203,10 @@ def rapidfire(launchpad, fworker, qadapter, launch_dir='.', nlaunches=0, njobs_q
             block_dir = create_datestamp_dir(launch_dir, l_logger)
 
         while True:
-            # get number of jobs in queue
-            jobs_in_queue = _get_number_of_jobs_in_queue(qadapter, njobs_queue, l_logger)
+            # get number of jobs in queue if a maximum has been set.
+            jobs_in_queue = 0
+            if njobs_queue:
+                jobs_in_queue = _get_number_of_jobs_in_queue(qadapter, njobs_queue, l_logger)
             job_counter = 0  # this is for QSTAT_FREQUENCY option
 
             while (launchpad.run_exists(fworker) or
@@ -244,7 +247,7 @@ def rapidfire(launchpad, fworker, qadapter, launch_dir='.', nlaunches=0, njobs_q
                 time.sleep(QUEUE_UPDATE_INTERVAL)
                 jobs_in_queue += 1
                 job_counter += 1
-                if job_counter % QSTAT_FREQUENCY == 0:
+                if job_counter % QSTAT_FREQUENCY == 0 and njobs_queue:
                     job_counter = 0
                     jobs_in_queue = _get_number_of_jobs_in_queue(qadapter, njobs_queue, l_logger)
 

--- a/fireworks/scripts/qlaunch_run.py
+++ b/fireworks/scripts/qlaunch_run.py
@@ -140,7 +140,7 @@ def qlaunch():
                         action='store_true')
 
     rapid_parser.add_argument('-m', '--maxjobs_queue',
-                              help='maximum jobs to keep in queue for this user', default=0,
+                              help='maximum jobs to keep in queue for this user. 0 for no limit', default=0,
                               type=int)
     rapid_parser.add_argument('-b', '--maxjobs_block',
                               help='maximum jobs to put in a block',

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -43,7 +43,7 @@ class CommonAdapter(QueueAdapterBase):
         "MOAB": {"submit_cmd": "msub", "status_cmd": "showq"}
     }
 
-    def __init__(self, q_type, q_name=None, template_file=None, **kwargs):
+    def __init__(self, q_type, q_name=None, template_file=None, timeout=None, **kwargs):
         """
         :param q_type: The type of queue. Right now it should be either PBS,
                        SGE, SLURM, Cobalt or LoadLeveler.
@@ -52,6 +52,8 @@ class CommonAdapter(QueueAdapterBase):
                               None (the default) to use Fireworks' built-in
                               templates for PBS and SGE, which should work
                               on most queues.
+        :param timeout: The amount of seconds to wait before raising an error when
+                        checking the number of jobs in the queue. Default 5 seconds.
         :param **kwargs: Series of keyword args for queue parameters.
         """
         if q_type not in CommonAdapter.default_q_commands:
@@ -63,6 +65,7 @@ class CommonAdapter(QueueAdapterBase):
         self.template_file = os.path.abspath(template_file) if template_file is not None else \
             CommonAdapter._get_default_template_file(q_type)
         self.q_name = q_name or q_type
+        self.timeout = timeout or 5
         self.update(dict(kwargs))
 
         self.q_commands = copy.deepcopy(CommonAdapter.default_q_commands)
@@ -254,7 +257,7 @@ class CommonAdapter(QueueAdapterBase):
 
         # run qstat
         qstat = Command(self._get_status_cmd(username))
-        p = qstat.run(timeout=5)
+        p = qstat.run(timeout=self.timeout)
 
         # parse the result
         if p[0] == 0:
@@ -283,6 +286,7 @@ class CommonAdapter(QueueAdapterBase):
             d["_fw_q_name"] = self.q_name
         if self.template_file != CommonAdapter._get_default_template_file(self.q_type):
             d["_fw_template_file"] = self.template_file
+        d["_fw_timeout"] = self.timeout
         return d
 
     @classmethod
@@ -291,4 +295,5 @@ class CommonAdapter(QueueAdapterBase):
             q_type=m_dict["_fw_q_type"],
             q_name=m_dict.get("_fw_q_name"),
             template_file=m_dict.get("_fw_template_file"),
+            timeout=m_dict.get("_fw_timeout"),
             **{k: v for k, v in m_dict.items() if not k.startswith("_fw")})


### PR DESCRIPTION
Sometimes the queuing system is not responsive and when running `qlaunch`the check for the number of jobs goes in timeout. Two improvements implemented here to avoid this issue:
* if the maximum jobs in the queue is 0 (no limit), do not check the current number of jobs. 
* added a timeout option to the `CommonAdapter`. Before the timeout was hardcoded to 5 seconds.