### PR TITLE
Avoid failures due to encoding issues in tracker

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -375,7 +375,7 @@ class Tracker(FWSerializable, object):
         if self.allow_zipped:
             m_file = zpath(m_file)
         if os.path.exists(m_file):
-            with zopen(m_file, "rt") as f:
+            with zopen(m_file, "rt", errors='surrogateescape') as f:
                 for l in reverse_readline(f):
                     lines.append(l)
                     if len(lines) == self.nlines:


### PR DESCRIPTION
Tracking files in text mode used to cause Fireworks to fail if encoding issues arose.
This pull request or specifying a particular encoding, i.e. "utf-8" should avoid such failures.