### PR TITLE
Extended GetFilesByQueryTask

### DIFF
--- a/fireworks/user_objects/firetasks/filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/filepad_tasks.py
@@ -108,6 +108,8 @@ class GetFilesByQueryTask(FiretaskBase):
           directory.
         - new_file_names ([str]): if provided, the retrieved files will be
           renamed. Not recommended as order and number of queried files not fixed.
+        - meta_file (bool): default: False. If True, then metadata of queried files written to
+          a .yaml file of same name as file itself, suffixed by...
         - meta_file_suffix (str): if not None, metadata for each file is written
           to a YAML file of the same name, suffixed by this string.
           Default: ".meta.yaml"
@@ -134,6 +136,7 @@ class GetFilesByQueryTask(FiretaskBase):
         fizzle_empty_result         = self.get("fizzle_empty_result", True)
         fizzle_degenerate_file_name = self.get("fizzle_degenerate_file_name",
                                                 True)
+        meta_file                   = self.get("meta_file",False)
         meta_file_suffix            = self.get("meta_file_suffix",".meta.yaml")
 
         assert isinstance(query,dict)
@@ -159,12 +162,13 @@ class GetFilesByQueryTask(FiretaskBase):
             with open(os.path.join(dest_dir, file_name), "wb") as f:
                 f.write(file_contents)
 
-            meta_file_name = file_name + meta_file_suffix
-            try:
-              with open(os.path.join(dest_dir, meta_file_name), "w") as f:
-                  yaml.dump(doc["metadata"], f, default_flow_style=False)
-            except:
-              pass # ignore error writing metadata, TODO: warn
+            if meta_file:
+              meta_file_name = file_name + meta_file_suffix
+              try:
+                with open(os.path.join(dest_dir, meta_file_name), "w") as f:
+                    yaml.dump(doc["metadata"], f, default_flow_style=False)
+              except:
+                pass # ignore error writing metadata, TODO: warn
 
 class DeleteFilesTask(FiretaskBase):
     """

--- a/fireworks/user_objects/firetasks/filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/filepad_tasks.py
@@ -87,13 +87,14 @@ class GetFilesTask(FiretaskBase):
 
 class GetFilesByQueryTask(FiretaskBase):
     """
-    A Firetask to fetch files from the filepad and write it to specified directory (current working
-    directory if not specified)
+    A Firetask to query files from the filepad and write them to specified
+    directory (current working directory if not specified).
 
     Required params:
         - query (dict): mongo db query identifying files to fetch.
           Same as within fireworks.utilities.dict_mods, use '->' in dict keys
           for querying nested documents, instead of MongoDB '.' (dot) seperator.
+          Do use '.' and NOT '->' within the 'sort_key' field.
 
     Optional params:
         - sort_key (str): sort key, don't sort per default
@@ -113,6 +114,19 @@ class GetFilesByQueryTask(FiretaskBase):
         - meta_file_suffix (str): if not None, metadata for each file is written
           to a YAML file of the same name, suffixed by this string.
           Default: ".meta.yaml"
+
+    The options 'fizzle_degenerate_file_name', 'limit', 'sort_key', and
+    'sort_direction' are all inntended to help dealing with the following
+    special case: Querying by metadata leads to an a priori unknown
+    number of files in the general case. Thus, it is advisable to either
+    'limit' the number of files and/or avoid explicitly specifying a list
+    of 'new_file_names'. In the latter case, files will be written to
+    'dest_dir' using their 'original_file_name' recorded within the
+    attached FilePad object. When more than one queried file share the same
+    'original_file_name', the order of processing matters: subsequent files will
+    overwrite their predecessor of same name. 'sort_key' and 'sort_direction'
+    can help to assure deterministic behavior, e.g. by always processing newer
+    files later.
     """
     _fw_name = 'GetFilesByQueryTask'
     required_params = ["query"]

--- a/fireworks/user_objects/firetasks/filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/filepad_tasks.py
@@ -116,11 +116,15 @@ class GetFilesByQueryTask(FiretaskBase):
     """
     _fw_name = 'GetFilesByQueryTask'
     required_params = ["query"]
-    optional_params = ["sort_key","sort_direction", "limit",
-        "filepad_file", "dest_dir", "new_file_names", "meta_file_suffix"]
+    optional_params = [
+        "dest_dir", "filepad_file",
+        "fizzle_degenerate_file_name", "fizzle_empty_result",
+        "limit", "meta_file", "meta_file_suffix", "new_file_names",
+        "sort_direction", "sort_key"]
 
     def run_task(self, fw_spec):
-        import pymongo, json, yaml
+        import pymongo, json
+        from ruamel.yaml import YAML
         from fireworks.utilities.dict_mods import arrow_to_dot
 
         fpad                        = get_fpad(self.get("filepad_file",
@@ -141,7 +145,7 @@ class GetFilesByQueryTask(FiretaskBase):
 
         assert isinstance(query,dict)
         query = arrow_to_dot(query)
-
+        
         l = fpad.get_file_by_query(query,sort_key,sort_direction)
         assert isinstance(l, list)
 
@@ -163,12 +167,10 @@ class GetFilesByQueryTask(FiretaskBase):
                 f.write(file_contents)
 
             if meta_file:
-              meta_file_name = file_name + meta_file_suffix
-              try:
+                meta_file_name = file_name + meta_file_suffix
                 with open(os.path.join(dest_dir, meta_file_name), "w") as f:
-                    yaml.dump(doc["metadata"], f, default_flow_style=False)
-              except:
-                pass # ignore error writing metadata, TODO: warn
+                    yaml = YAML()
+                    yaml.dump(doc["metadata"], f)
 
 class DeleteFilesTask(FiretaskBase):
     """

--- a/fireworks/user_objects/firetasks/filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/filepad_tasks.py
@@ -7,8 +7,8 @@ import os
 from fireworks.core.firework import FiretaskBase
 from fireworks.utilities.filepad import FilePad
 
-__author__ = 'Kiran Mathew'
-__email__ = 'kmathew@lbl.gov'
+__author__ = 'Kiran Mathew, Johannes Hoermann'
+__email__ = 'kmathew@lbl.gov, johannes.hoermann@imtek.uni-freiburg.de'
 __credits__ = 'Anubhav Jain'
 
 
@@ -145,7 +145,7 @@ class GetFilesByQueryTask(FiretaskBase):
 
         assert isinstance(query,dict)
         query = arrow_to_dot(query)
-        
+
         l = fpad.get_file_by_query(query,sort_key,sort_direction)
         assert isinstance(l, list)
 

--- a/fireworks/user_objects/firetasks/filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/filepad_tasks.py
@@ -91,38 +91,80 @@ class GetFilesByQueryTask(FiretaskBase):
     directory if not specified)
 
     Required params:
-        - query (dict): mongo db query identifying files to fetch
+        - query (dict): mongo db query identifying files to fetch.
+          Same as within fireworks.utilities.dict_mods, use '->' in dict keys
+          for querying nested documents, instead of MongoDB '.' (dot) seperator.
 
     Optional params:
         - sort_key (str): sort key, don't sort per default
         - sort_direction (int): sort direction, default 'pymongo.DESCENDING'
         - limit (int): maximum number of files to write, default: no limit
+        - fizzle_empty_result (bool): fizzle if no file found, default: True
+        - fizzle_degenerate_file_name (bool): fizzle if more than one of the
+          resulting files are to be written to the same local file (i.e. the
+          filepad's 'original_file_name' entries overlap), default: True
         - filepad_file (str): path to the filepad db config file
         - dest_dir (str): destination directory, default is the current working
           directory.
         - new_file_names ([str]): if provided, the retrieved files will be
           renamed. Not recommended as order and number of queried files not fixed.
+        - meta_file_suffix (str): if not None, metadata for each file is written
+          to a YAML file of the same name, suffixed by this string.
+          Default: ".meta.yaml"
     """
     _fw_name = 'GetFilesByQueryTask'
     required_params = ["query"]
     optional_params = ["sort_key","sort_direction", "limit",
-        "filepad_file", "dest_dir", "new_file_names"]
+        "filepad_file", "dest_dir", "new_file_names", "meta_file_suffix"]
 
     def run_task(self, fw_spec):
-        import pymongo
-        fpad = get_fpad(self.get("filepad_file", None))
-        dest_dir = self.get("dest_dir", os.path.abspath("."))
-        new_file_names = self.get("new_file_names", [])
-        query = self.get("query", {})
-        sort_key = self.get("sort_key", None)
-        sort_direction = self.get("sort_direction", pymongo.DESCENDING)
-        limit = self.get("limit",None)
+        import pymongo, json, yaml
+        from fireworks.utilities.dict_mods import arrow_to_dot
+
+        fpad                        = get_fpad(self.get("filepad_file",
+                                                None))
+        dest_dir                    = self.get("dest_dir",
+                                                os.path.abspath("."))
+        new_file_names              = self.get("new_file_names", [])
+        query                       = self.get("query", {})
+        sort_key                    = self.get("sort_key", None)
+        sort_direction              = self.get("sort_direction",
+                                                pymongo.DESCENDING)
+        limit                       = self.get("limit",None)
+        fizzle_empty_result         = self.get("fizzle_empty_result", True)
+        fizzle_degenerate_file_name = self.get("fizzle_degenerate_file_name",
+                                                True)
+        meta_file_suffix            = self.get("meta_file_suffix",".meta.yaml")
+
+        assert isinstance(query,dict)
+        query = arrow_to_dot(query)
 
         l = fpad.get_file_by_query(query,sort_key,sort_direction)
+        assert isinstance(l, list)
+
+        if fizzle_empty_result and ( len(l) == 0 ):
+            raise ValueError("Query yielded empty result! (query: {:s})".format(
+              json.dumps(query)
+            ))
+
+        unique_file_names = set() # track all used file names
         for i, (file_contents, doc) in enumerate(l[:limit]):
             file_name = new_file_names[i] if new_file_names else doc["original_file_name"]
+            if fizzle_degenerate_file_name and (file_name in unique_file_names):
+                raise ValueError(' '.join(("The local file name {:s} is used",
+                  "a second time by result {:d}/{:d}! (query: {:s})")).format(
+                    file_name, i, len(l), json.dumps(query)))
+
+            unique_file_names.add(file_name)
             with open(os.path.join(dest_dir, file_name), "wb") as f:
                 f.write(file_contents)
+
+            meta_file_name = file_name + meta_file_suffix
+            try:
+              with open(os.path.join(dest_dir, meta_file_name), "w") as f:
+                  yaml.dump(doc["metadata"], f, default_flow_style=False)
+            except:
+              pass # ignore error writing metadata, TODO: warn
 
 class DeleteFilesTask(FiretaskBase):
     """

--- a/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
@@ -164,7 +164,7 @@ class FilePadTasksTest(unittest.TestCase):
         # test successful if no exception raised
 
     def test_getfilesbyquerytask_raise_degenerate_file_name(self):
-        '''Tests on raising degenrate file name in result from FilePad query'''
+        '''Tests on raising exception on degenerate file name from FilePad query'''
         with open("degenerate_file.txt",'w') as f:
             f.write("Some file with some content")
         t = AddFilesTask(paths=["degenerate_file.txt"],

--- a/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
@@ -6,8 +6,9 @@ __author__ = 'Kiran Mathew'
 
 import unittest
 import os
+import yaml
 
-from fireworks.user_objects.firetasks.filepad_tasks import AddFilesTask, DeleteFilesTask, GetFilesTask
+from fireworks.user_objects.firetasks.filepad_tasks import AddFilesTask, DeleteFilesTask, GetFilesTask, GetFilesByQueryTask
 from fireworks.utilities.filepad import FilePad
 
 
@@ -46,6 +47,38 @@ class FilePadTasksTest(unittest.TestCase):
         identifiers = ["write"]
         new_file_names = ["write_2.yaml"]
         t = GetFilesTask(identifiers=identifiers, dest_dir=dest_dir, new_file_names=new_file_names)
+        t.run_task({})
+        write_file_contents, _ = self.fp.get_file("write")
+        self.assertEqual(write_file_contents,
+                         open(os.path.join(dest_dir, new_file_names[0]), "r").read().encode())
+        os.remove(os.path.join(dest_dir, new_file_names[0]))
+
+    def test_getfilesbyquerytask_run(self):
+        t = AddFilesTask(paths=self.paths, identifiers=self.identifiers,
+          metadata={'key': 'value'})
+        t.run_task({})
+        dest_dir = os.path.abspath(".")
+        identifiers = ["write"]
+        new_file_names = ["write_2.yaml"]
+        t = GetFilesByQueryTask(
+          query={'metadata->key': 'value'},
+          dest_dir=dest_dir, new_file_names=new_file_names)
+        t.run_task({})
+        write_file_contents, _ = self.fp.get_file("write")
+        self.assertEqual(write_file_contents,
+                         open(os.path.join(dest_dir, new_file_names[0]), "r").read().encode())
+        os.remove(os.path.join(dest_dir, new_file_names[0]))
+
+    def test_getfilesbyquerytask_metafile_run(self):
+        t = AddFilesTask(paths=self.paths, identifiers=self.identifiers,
+          metadata={'key': 'value'})
+        t.run_task({})
+        dest_dir = os.path.abspath(".")
+        identifiers = ["write"]
+        new_file_names = ["write_2.yaml"]
+        t = GetFilesByQueryTask(
+          query={'metadata->key': 'value'}, meta_file=True,
+          dest_dir=dest_dir, new_file_names=new_file_names)
         t.run_task({})
         write_file_contents, _ = self.fp.get_file("write")
         self.assertEqual(write_file_contents,

--- a/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-__author__ = 'Kiran Mathew'
+__author__ = 'Kiran Mathew, Johannes Hoermann'
 
 import unittest
 import os

--- a/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
@@ -6,7 +6,7 @@ __author__ = 'Kiran Mathew'
 
 import unittest
 import os
-import yaml
+from ruamel.yaml import YAML
 
 from fireworks.user_objects.firetasks.filepad_tasks import AddFilesTask, DeleteFilesTask, GetFilesTask, GetFilesByQueryTask
 from fireworks.utilities.filepad import FilePad
@@ -18,7 +18,9 @@ module_dir = os.path.abspath(os.path.dirname(__file__))
 class FilePadTasksTest(unittest.TestCase):
 
     def setUp(self):
-        self.paths = [os.path.join(module_dir, "write.yaml"), os.path.join(module_dir, "delete.yaml")]
+        self.paths = [
+            os.path.join(module_dir, "write.yaml"),
+            os.path.join(module_dir, "delete.yaml")]
         self.identifiers = ["write", "delete"]
         self.fp = FilePad.auto_load()
 
@@ -26,9 +28,11 @@ class FilePadTasksTest(unittest.TestCase):
         t = AddFilesTask(paths=self.paths, identifiers=self.identifiers)
         t.run_task({})
         write_file_contents, _ = self.fp.get_file("write")
-        self.assertEqual(write_file_contents, open(self.paths[0], "r").read().encode())
+        with open(self.paths[0], "r") as f:
+            self.assertEqual(write_file_contents, f.read().encode())
         del_file_contents, _ = self.fp.get_file("delete")
-        self.assertEqual(del_file_contents, open(self.paths[1], "r").read().encode())
+        with open(self.paths[1], "r") as f:
+            self.assertEqual(del_file_contents, f.read().encode())
 
     def test_deletefilestask_run(self):
         t = DeleteFilesTask(identifiers=self.identifiers)
@@ -49,49 +53,215 @@ class FilePadTasksTest(unittest.TestCase):
         t = GetFilesTask(identifiers=identifiers, dest_dir=dest_dir, new_file_names=new_file_names)
         t.run_task({})
         write_file_contents, _ = self.fp.get_file("write")
-        self.assertEqual(write_file_contents,
-                         open(os.path.join(dest_dir, new_file_names[0]), "r").read().encode())
+        with open(os.path.join(dest_dir, new_file_names[0]), "r") as f:
+            self.assertEqual(write_file_contents, f.read().encode())
         os.remove(os.path.join(dest_dir, new_file_names[0]))
 
     def test_getfilesbyquerytask_run(self):
+        '''Tests querying objects from FilePad by metadata'''
         t = AddFilesTask(paths=self.paths, identifiers=self.identifiers,
           metadata={'key': 'value'})
         t.run_task({})
         dest_dir = os.path.abspath(".")
-        identifiers = ["write"]
-        new_file_names = ["write_2.yaml"]
+        identifiers = ["test_idenfifier"]
+        new_file_names = ["test_file.yaml"]
         t = GetFilesByQueryTask(
           query={'metadata->key': 'value'},
           dest_dir=dest_dir, new_file_names=new_file_names)
         t.run_task({})
-        write_file_contents, _ = self.fp.get_file("write")
-        self.assertEqual(write_file_contents,
+        test_file_contents, _ = self.fp.get_file("test_idenfifier")
+        self.assertEqual(test_file_contents,
                          open(os.path.join(dest_dir, new_file_names[0]), "r").read().encode())
         os.remove(os.path.join(dest_dir, new_file_names[0]))
 
-    def test_getfilesbyquerytask_metafile_run(self):
-        t = AddFilesTask(paths=self.paths, identifiers=self.identifiers,
-          metadata={'key': 'value'})
+    def test_getfilesbyquerytask_run(self):
+        '''Tests querying objects from FilePad by metadata'''
+        with open("original_test_file.txt",'w') as f:
+            f.write("Some file with some content")
+        t = AddFilesTask(
+            paths=["original_test_file.txt"],
+            identifiers=["some_identifier"],
+            metadata={'key': 'value'})
         t.run_task({})
+        os.remove("original_test_file.txt")
+
         dest_dir = os.path.abspath(".")
-        identifiers = ["write"]
-        new_file_names = ["write_2.yaml"]
         t = GetFilesByQueryTask(
-          query={'metadata->key': 'value'}, meta_file=True,
-          dest_dir=dest_dir, new_file_names=new_file_names)
+            query={'metadata->key': 'value'},
+            dest_dir=dest_dir, new_file_names=["queried_test_file.txt"])
         t.run_task({})
-        write_file_contents, _ = self.fp.get_file("write")
-        self.assertEqual(write_file_contents,
-                         open(os.path.join(dest_dir, new_file_names[0]), "r").read().encode())
-        os.remove(os.path.join(dest_dir, new_file_names[0]))
+        test_file_contents, _ = self.fp.get_file("some_identifier")
+        with open(os.path.join(dest_dir, "queried_test_file.txt"), "r") as f:
+            self.assertEqual(test_file_contents, f.read().encode())
+        os.remove(os.path.join(dest_dir, "queried_test_file.txt"))
+
+    def test_getfilesbyquerytask_metafile_run(self):
+        '''Tests writing metadata to a yaml file'''
+        with open("original_test_file.txt",'w') as f:
+            f.write("Some file with some content")
+        t = AddFilesTask(
+            paths=["original_test_file.txt"],
+            identifiers=["test_identifier"],
+            metadata={'key': 'value'})
+        t.run_task({})
+        os.remove("original_test_file.txt")
+
+        dest_dir = os.path.abspath(".")
+        t = GetFilesByQueryTask(
+            query={'metadata->key': 'value'},
+            meta_file=True, meta_file_suffix='.meta.yaml',
+            dest_dir=dest_dir, new_file_names=["queried_test_file.txt"])
+        t.run_task({})
+
+        with open('queried_test_file.txt.meta.yaml', 'r') as f:
+            yaml=YAML(typ='safe')
+            metadata = yaml.load(f)
+        self.assertEqual(metadata["key"], "value")
+
+        os.remove(os.path.join(dest_dir, 'queried_test_file.txt'))
+        os.remove(os.path.join(dest_dir, 'queried_test_file.txt.meta.yaml'))
+
+    def test_getfilesbyquerytask_ignore_empty_result_run(self):
+        '''Tests on ignoring empty results from FilePad query'''
+        dest_dir = os.path.abspath(".")
+        t = GetFilesByQueryTask(
+            query={'metadata->key': 'value'}, fizzle_empty_result=False,
+            dest_dir=dest_dir, new_file_names=["queried_test_file.txt"])
+        t.run_task({})
+        # test successful if no exception raised
+
+    def test_getfilesbyquerytask_raise_empty_result_run(self):
+        '''Tests on raising exception on empty results from FilePad query'''
+        dest_dir = os.path.abspath(".")
+        t = GetFilesByQueryTask(
+            query={'metadata->key': 'value'}, fizzle_empty_result=True,
+            dest_dir=dest_dir, new_file_names=['queried_test_file.txt'])
+        with self.assertRaises(ValueError):
+            t.run_task({})
+        # test successful if exception raised
+
+    def test_getfilesbyquerytask_ignore_degenerate_file_name(self):
+        '''Tests on ignoring degenrate file name in result from FilePad query'''
+        with open("degenerate_file.txt",'w') as f:
+            f.write("Some file with some content")
+        t = AddFilesTask(paths=["degenerate_file.txt"],
+            identifiers=["some_identifier"],
+            metadata={'key': 'value'})
+        t.run_task({})
+
+        with open("degenerate_file.txt",'w') as f:
+            f.write("Some other file with some other content BUT same file name")
+        t = AddFilesTask(paths=["degenerate_file.txt"],
+            identifiers=["some_other_identifier"],
+            metadata={'key': 'value'})
+        t.run_task({})
+
+        os.remove("degenerate_file.txt")
+
+        t = GetFilesByQueryTask(
+            query={'metadata->key': 'value'}, fizzle_degenerate_file_name=False)
+        t.run_task({})
+        # test successful if no exception raised
+
+    def test_getfilesbyquerytask_raise_degenerate_file_name(self):
+        '''Tests on raising degenrate file name in result from FilePad query'''
+        with open("degenerate_file.txt",'w') as f:
+            f.write("Some file with some content")
+        t = AddFilesTask(paths=["degenerate_file.txt"],
+            identifiers=["some_identifier"],
+            metadata={'key': 'value'})
+        t.run_task({})
+
+        with open("degenerate_file.txt",'w') as f:
+            f.write("Some other file with some other content BUT same file name")
+        t = AddFilesTask(paths=["degenerate_file.txt"],
+            identifiers=["some_other_identifier"],
+            metadata={'key': 'value'})
+        t.run_task({})
+
+        os.remove("degenerate_file.txt")
+
+        t = GetFilesByQueryTask(
+            query={'metadata->key': 'value'}, fizzle_degenerate_file_name=True)
+        with self.assertRaises(ValueError):
+            t.run_task({})
+        # test successful if exception raised
+
+    def test_getfilesbyquerytask_sort_ascending_name_run(self):
+        '''Tests on sorting queried files in ascending order'''
+        file_contents = [
+            'Some file with some content',
+            'Some other file with some other content' ]
+
+        with open("degenerate_file.txt",'w') as f:
+            f.write(file_contents[0])
+        t = AddFilesTask(paths=["degenerate_file.txt"],
+            identifiers=["some_identifier"],
+            metadata={'key': 'value', 'sort_key': 0})
+        t.run_task({})
+
+        with open("degenerate_file.txt",'w') as f:
+            f.write(file_contents[-1])
+        t = AddFilesTask(paths=["degenerate_file.txt"],
+            identifiers=["some_other_identifier"],
+            metadata={'key': 'value', 'sort_key': 1})
+        t.run_task({})
+
+        os.remove("degenerate_file.txt")
+
+        t = GetFilesByQueryTask(
+            query={'metadata->key': 'value'},
+            fizzle_degenerate_file_name=False,
+            sort_key="sort_key",
+            sort_direction=1)
+        t.run_task({})
+
+        with open("degenerate_file.txt", "r") as f:
+            self.assertEqual(file_contents[-1],f.read())
+
+    def test_getfilesbyquerytask_sort_descending_name_run(self):
+        '''Tests on sorting queried files in descending order'''
+        file_contents = [
+            'Some file with some content',
+            'Some other file with some other content' ]
+
+        with open("degenerate_file.txt",'w') as f:
+            f.write(file_contents[0])
+        t = AddFilesTask(paths=["degenerate_file.txt"],
+            identifiers=["some_identifier"],
+            metadata={'key': 'value', 'sort_key': 10})
+        t.run_task({})
+
+        with open("degenerate_file.txt",'w') as f:
+            f.write(file_contents[-1])
+        t = AddFilesTask(paths=["degenerate_file.txt"],
+            identifiers=["some_other_identifier"],
+            metadata={'key': 'value', 'sort_key': 20})
+        t.run_task({})
+
+        os.remove("degenerate_file.txt")
+
+        t = GetFilesByQueryTask(
+            query={'metadata->key': 'value'},
+            fizzle_degenerate_file_name=False,
+            sort_key="metadata.sort_key",
+            sort_direction=-1)
+        t.run_task({})
+
+        with open("degenerate_file.txt", "r") as f:
+            self.assertEqual(file_contents[0],f.read())
+
+        os.remove("degenerate_file.txt")
 
     def test_addfilesfrompatterntask_run(self):
         t = AddFilesTask(paths="*.yaml", directory=module_dir)
         t.run_task({})
         write_file_contents, _ = self.fp.get_file(self.paths[0])
-        self.assertEqual(write_file_contents, open(self.paths[0], "r").read().encode())
+        with open(self.paths[0], "r") as f:
+            self.assertEqual(write_file_contents, f.read().encode())
         del_file_contents, wdoc = self.fp.get_file(self.paths[1])
-        self.assertEqual(del_file_contents, open(self.paths[1], "r").read().encode())
+        with open(self.paths[1], "r") as f:
+            self.assertEqual(del_file_contents, f.read().encode())
 
     def tearDown(self):
         self.fp.reset()

--- a/fireworks/utilities/dict_mods.py
+++ b/fireworks/utilities/dict_mods.py
@@ -34,6 +34,22 @@ def get_nested_dict(input_dict, key):
             return current, toks[-1]
         current = current[tok]
 
+def arrow_to_dot(input_dict):
+    """
+    Converts arrows ('->') in dict keys to dots '.' recursively.
+    Allows for storing MongoDB neseted document queries in MongoDB.
+
+    Args:
+      input_dict (dict)
+
+    Returns:
+      dict
+    """
+    if not isinstance(input_dict,dict):
+      return input_dict
+    else:
+      return {
+        k.replace("->","."): arrow_to_dot(v) for k, v in input_dict.items() }
 
 @singleton
 class DictMods(object):


### PR DESCRIPTION
A suggestion:

Turns the previously contributed "GetFilesByQueryTask" into something useful:

- Allows for nested queries to be stored by using "->" instead of "." separator.
- Different options to handle a priori uncertain number and names of queried files (see task's doc string)
- Tests for these added features (also serving documentation purposes)

Other additions:
- Use with-statement to enforce closing all file streams in other FilePad-Task tests, avoid warnings
- Tiny helper function "arrow_to_dot" within "utilities/dict_mods.py" facilitates "->" to "." conversion.

Best regards,

Johannes