### PR TITLE
Fix a bug about "Could not get number of jobs in queue"

### DIFF
--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -181,6 +181,7 @@ class CommonAdapter(QueueAdapterBase):
                     # note: the entire queue name might be cutoff from the output if long queue name
                     # so we are only ensuring that our queue matches up until cutoff point
                     if "queue" in self :
+                        # if "queue" is not in self, an error('NoneType' object is not subscriptable) will occure
                         if self["queue"][0:len(toks[queue_index])] in toks[queue_index]:
                             count += 1
 

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -180,8 +180,9 @@ class CommonAdapter(QueueAdapterBase):
                 if toks[state_index] != "C":
                     # note: the entire queue name might be cutoff from the output if long queue name
                     # so we are only ensuring that our queue matches up until cutoff point
-                    if "queue" in self and self["queue"][0:len(toks[queue_index])] in toks[queue_index]:
-                        count += 1
+                    if "queue" in self :
+                        if self["queue"][0:len(toks[queue_index])] in toks[queue_index]:
+                            count += 1
 
         return count
 

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -180,7 +180,7 @@ class CommonAdapter(QueueAdapterBase):
                 if toks[state_index] != "C":
                     # note: the entire queue name might be cutoff from the output if long queue name
                     # so we are only ensuring that our queue matches up until cutoff point
-                    if "queue" in self :
+                    if "queue" in self:
                         # if "queue" is not in self, an error('NoneType' object is not subscriptable) will occure
                         if self["queue"][0:len(toks[queue_index])] in toks[queue_index]:
                             count += 1

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         name='FireWorks',
         version="1.9.5",
         description='FireWorks workflow software',
-        long_description=open(os.path.join(module_dir, 'README.md')).read(),
+        long_description=open(os.path.join(module_dir, 'README.md'), encoding='utf-8').read(),
         url='https://github.com/materialsproject/fireworks',
         author='Anubhav Jain',
         author_email='anubhavster@gmail.com',


### PR DESCRIPTION
if "queue" is not in self, an error('NoneType' object is not subscriptable) will occure

Detail error:

2020-02-02 22:11:50,444 ERROR ----|vvv|----
2020-02-02 22:11:50,444 ERROR Could not get number of jobs in queue! Sleeping 30 secs...zzz...
2020-02-02 22:11:50,462 ERROR Traceback (most recent call last):
  File "/storage/home/m/mjl6505/venv/atomate/lib/python3.6/site-packages/fireworks/queue/queue_launcher.py", line 294, in _get_number_of_jobs_in_queue
    jobs_in_queue = qadapter.get_njobs_in_queue()
  File "/storage/home/m/mjl6505/venv/atomate/lib/python3.6/site-packages/fireworks/user_objects/queue_adapters/common_adapter.py", line 270, in get_njobs_in_queue
    njobs = self._parse_njobs(p[1], username)
  File "/storage/home/m/mjl6505/venv/atomate/lib/python3.6/site-packages/fireworks/user_objects/queue_adapters/common_adapter.py", line 189, in _parse_njobs
    if "queue" in self and self["queue"][0:len(toks[queue_index])] in toks[queue_index]:
TypeError: 'NoneType' object is not subscriptable
