### PR TITLE
bugfixes: global import of dagflow module; copy() of dagflow replaced

### DIFF
--- a/fireworks/utilities/dagflow.py
+++ b/fireworks/utilities/dagflow.py
@@ -85,10 +85,10 @@ class DAGFlow(Graph):
                 step_data.extend(task_input(true_task, spec))
                 if 'outputs' in true_task:
                     assert isinstance(true_task['outputs'], list), (
-                            'outputs must be a list in fw_id ' + str(step['id']))
+                        'outputs must be a list in fw_id ' + str(step['id']))
                 if 'inputs' in true_task:
                     assert isinstance(true_task['inputs'], list), (
-                            'inputs must be a list in fw_id ' + str(step['id']))
+                        'inputs must be a list in fw_id ' + str(step['id']))
             step['data'] = list(set(step_data))
 
         return cls(steps=steps, links=links, name=name)
@@ -105,7 +105,7 @@ class DAGFlow(Graph):
     def _get_ctrlflow_links(self):
         """ Returns a list of unique tuples of link ids """
         links = []
-        for ilink in set([link.tuple for link in list(self.es)]):
+        for ilink in {link.tuple for link in list(self.es)}:
             source = self.vs[ilink[0]]['id']
             target = self.vs[ilink[1]]['id']
             links.append((source, target))
@@ -198,7 +198,7 @@ class DAGFlow(Graph):
 
         # data chunks distributed over several sibling steps
         for task in step['_tasks']:
-            step['chunk'] = True if 'chunk_number' in task else False
+            step['chunk'] = 'chunk_number' in task
 
     def _get_steps(self):
         """ Returns a list of dictionaries describing the steps """
@@ -213,7 +213,9 @@ class DAGFlow(Graph):
         """ Returns the vertex index for a step with provided id """
         for vertex in list(self.vs):
             if vertex['id'] == step_id:
-                return vertex.index
+                retval = vertex.index
+                break
+        return retval
 
     def _get_cycles(self):
         """ Returns a partial list of cycles in case of erroneous workflow """
@@ -224,7 +226,7 @@ class DAGFlow(Graph):
             flatten = lambda l: [item for sublist in l for item in sublist]
             if flatten(lst):
                 break
-        cycs = [list(x) for x in set([tuple(sorted(l)) for l in lst])]
+        cycs = [list(x) for x in {tuple(sorted(l)) for l in lst}]
         cycs = [[self.vs[ind]['id'] for ind in cycle] for cycle in cycs]
         return cycs
 
@@ -289,7 +291,7 @@ class DAGFlow(Graph):
 
     def to_dot(self, filename='wf.dot', view='combined'):
         """ Writes the workflow into a file in DOT format """
-        graph = self.copy()
+        graph = DAGFlow(**self.to_dict())
         if view == 'controlflow':
             graph.delete_dataflow_links()
         elif view == 'dataflow':

--- a/fireworks/utilities/tests/test_dagflow.py
+++ b/fireworks/utilities/tests/test_dagflow.py
@@ -10,18 +10,15 @@ import unittest
 from fireworks import PyTask, Firework, Workflow
 
 
-try:
-    __import__('igraph', fromlist=['Graph'])
-except (ImportError, ModuleNotFoundError):
-    raise unittest.SkipTest('Skipping because python-igraph not installed')
-else:
-    from fireworks.utilities.dagflow import DAGFlow
-
-
 class DAGFlowTest(unittest.TestCase):
     """ run tests for DAGFlow class """
 
     def setUp(self):
+        try:
+            __import__('igraph', fromlist=['Graph'])
+        except (ImportError, ModuleNotFoundError):
+            raise unittest.SkipTest('Skipping because python-igraph not installed')
+
         self.fw1 = Firework(
             PyTask(
                 func='math.pow',
@@ -50,6 +47,7 @@ class DAGFlowTest(unittest.TestCase):
 
     def test_dagflow_ok(self):
         """ construct and replicate """
+        from fireworks.utilities.dagflow import DAGFlow
         wfl = Workflow(
             [self.fw1, self.fw2, self.fw3],
             {self.fw1: [self.fw2], self.fw2: [self.fw3], self.fw3: []}
@@ -59,6 +57,7 @@ class DAGFlowTest(unittest.TestCase):
 
     def test_dagflow_loop(self):
         """ loop in graph """
+        from fireworks.utilities.dagflow import DAGFlow
         wfl = Workflow(
             [self.fw1, self.fw2, self.fw3],
             {self.fw1: self.fw2, self.fw2: self.fw3, self.fw3: self.fw1}
@@ -70,6 +69,7 @@ class DAGFlowTest(unittest.TestCase):
 
     def test_dagflow_cut(self):
         """ disconnected graph """
+        from fireworks.utilities.dagflow import DAGFlow
         wfl = Workflow([self.fw1, self.fw2, self.fw3], {self.fw1: self.fw2})
         msg = 'The workflow graph must be connected'
         with self.assertRaises(AssertionError) as context:
@@ -78,6 +78,7 @@ class DAGFlowTest(unittest.TestCase):
 
     def test_dagflow_link(self):
         """ wrong links """
+        from fireworks.utilities.dagflow import DAGFlow
         wfl = Workflow(
             [self.fw1, self.fw2, self.fw3],
             {self.fw1: [self.fw2, self.fw3]}
@@ -89,6 +90,7 @@ class DAGFlowTest(unittest.TestCase):
 
     def test_dagflow_input(self):
         """ missing input """
+        from fireworks.utilities.dagflow import DAGFlow
         fw2 = Firework(
             PyTask(
                 func='math.pow',
@@ -106,6 +108,7 @@ class DAGFlowTest(unittest.TestCase):
 
     def test_dagflow_output(self):
         """ clashing inputs """
+        from fireworks.utilities.dagflow import DAGFlow
         fw2 = Firework(
             PyTask(
                 func='math.pow',
@@ -124,6 +127,7 @@ class DAGFlowTest(unittest.TestCase):
 
     def test_dagflow_view(self):
         """ visualize the workflow graph """
+        from fireworks.utilities.dagflow import DAGFlow
         wfl = Workflow(
             [self.fw1, self.fw2, self.fw3],
             {self.fw1: [self.fw2], self.fw2: [self.fw3], self.fw3: []}

--- a/fireworks/utilities/tests/test_dagflow.py
+++ b/fireworks/utilities/tests/test_dagflow.py
@@ -11,9 +11,11 @@ from fireworks import PyTask, Firework, Workflow
 
 
 try:
-    from fireworks.utilities.dagflow import DAGFlow
+    __import__('igraph', fromlist=['Graph'])
 except (ImportError, ModuleNotFoundError):
     raise unittest.SkipTest('Skipping because python-igraph not installed')
+else:
+    from fireworks.utilities.dagflow import DAGFlow
 
 
 class DAGFlowTest(unittest.TestCase):

--- a/fireworks/utilities/tests/test_dagflow.py
+++ b/fireworks/utilities/tests/test_dagflow.py
@@ -9,15 +9,15 @@ import uuid
 import unittest
 from fireworks import PyTask, Firework, Workflow
 
+try:
+    from fireworks.utilities.dagflow import DAGFlow
+except ImportError:
+    raise unittest.SkipTest('Skipping because python-igraph not installed')
+
 class DAGFlowTest(unittest.TestCase):
     """ run tests for DAGFlow class """
 
     def setUp(self):
-        try:
-            from fireworks.utilities.dagflow import DAGFlow
-        except Exception:
-            raise unittest.SkipTest("Skipping test, DagFlow not installed")
-
         self.fw1 = Firework(
             PyTask(
                 func='math.pow',
@@ -85,7 +85,6 @@ class DAGFlowTest(unittest.TestCase):
 
     def test_dagflow_input(self):
         """ missing input """
-
         fw2 = Firework(
             PyTask(
                 func='math.pow',

--- a/fireworks/utilities/tests/test_dagflow.py
+++ b/fireworks/utilities/tests/test_dagflow.py
@@ -9,10 +9,12 @@ import uuid
 import unittest
 from fireworks import PyTask, Firework, Workflow
 
+
 try:
     from fireworks.utilities.dagflow import DAGFlow
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     raise unittest.SkipTest('Skipping because python-igraph not installed')
+
 
 class DAGFlowTest(unittest.TestCase):
     """ run tests for DAGFlow class """


### PR DESCRIPTION
This solves the following issues:
* https://github.com/materialsproject/fireworks/issues/398: missing global import of `DAGFlow` class in the tests
* https://github.com/materialsproject/fireworks/issues/399: caused by some changes in python-igraph `Graph.copy()` method or due to change in python 3.8 deepcopy behavior