### PR TITLE
ENH: dagflow direct plot

### DIFF
--- a/fireworks/utilities/dagflow.py
+++ b/fireworks/utilities/dagflow.py
@@ -13,23 +13,30 @@ DF_TASKS = ['PyTask', 'CommandLineTask', 'ForeachTask', 'JoinDictTask',
             'JoinListTask']
 
 DEFAULT_IGRAPH_VISUAL_SYTLE = {
-    "bbox": (700, 500),
+    "bbox": (1280, 800),
     "margin": [200, 100, 200, 100],
-
-    # vertex defaults
-    "vertex_label_angle": -3.14/4.0,
-    "vertex_size": 8,
-    "vertex_shape": 'rectangle',
-    "vertex_label_size": 10,
-    "vertex_label_dist": 4,
-
-    # edge defaults
-    "edge_color": 'black',
-    "edge_width": 1,
-    "edge_arrow_size": 1,
-    "edge_arrow_width": 1,
-    "edge_label_size": 8,
+    "vertex_label_dist": 2,
 }
+
+# for graph visualization, code "roots" green (start), "leaves" red (end),
+# any other blue
+try:
+    import matplotlib
+    # only needed for color-coding with favorite named colors, not imported
+    # in top level as matplotlib is no Fireworks requirement.
+
+    DEFAULT_IGRAPH_VERTEX_COLOR_CODING = {
+        'root': matplotlib.colors.cnames['forestgreen'],
+        'leaf': matplotlib.colors.cnames['indianred'],
+        'other': matplotlib.colors.cnames['lightsteelblue'],
+    }
+except ImportError:
+    DEFAULT_IGRAPH_VERTEX_COLOR_CODING = {
+        'root': '#228B22',
+        'leaf': '#CD5C5C',
+        'other': '#B0C4DE',
+    }
+
 
 class DAGFlow(Graph):
     """ The purpose of this class is to help construction, validation and
@@ -400,27 +407,13 @@ def plot_wf(wf, view='combined', labels=False, **kwargs):
     dagf_roots = dagf._get_roots()
     dagf_leaves = dagf._get_leaves()
 
-    # code "roots" green (start), "leaves" red (end), any other blue
-    try:
-        import matplotlib
-        # only needed for color-coding with favorite named colors, not imported
-        # in top level as matplotlib is no Fireworks requirement.
-
-        def color_coding(v):
-            if v in dagf_roots:
-                return matplotlib.colors.cnames['forestgreen']
-            elif v in dagf_leaves:
-                return matplotlib.colors.cnames['indianred']
-            else:
-                return matplotlib.colors.cnames['lightsteelblue']
-    except ImportError:
-        def color_coding(v):
-            if v in dagf_roots:
-                return '#228B22'
-            elif v in dagf_leaves:
-                return '#CD5C5C'
-            else:
-                return '#B0C4DE'
+    def color_coding(v):
+        if v in dagf_roots:
+            return DEFAULT_IGRAPH_VERTEX_COLOR_CODING['root']
+        elif v in dagf_leaves:
+            return DEFAULT_IGRAPH_VERTEX_COLOR_CODING['leaf']
+        else:
+            return DEFAULT_IGRAPH_VERTEX_COLOR_CODING['other']
 
     visual_style["vertex_color"] = [color_coding(v) for v in range(dagf.vcount())]
 

--- a/fireworks/utilities/dagflow.py
+++ b/fireworks/utilities/dagflow.py
@@ -330,7 +330,7 @@ class DAGFlow(Graph):
         graph.write_dot(filename)
 
 
-def plot_wf(wf, view='combined', **kwargs):
+def plot_wf(wf, view='combined', labels=False, **kwargs):
     """Plot workflow via igraph.plot.
 
     Parameters:
@@ -347,7 +347,8 @@ def plot_wf(wf, view='combined', **kwargs):
     import matplotlib
 
     dagf = DAGFlow.from_fireworks(wf)
-    dagf.add_step_labels()
+    if labels:
+        dagf.add_step_labels()
 
     # copied from to_dot
     if view == 'controlflow':
@@ -385,12 +386,12 @@ def plot_wf(wf, view='combined', **kwargs):
     dagf_roots = dagf._get_roots()
     dagf_leaves = dagf._get_leaves()
 
-    # code "roots" red, "leaves" green, any other blue
+    # code "roots" green (start), "leaves" red (end), any other blue
     def color_coding(v):
         if v in dagf_roots:
-            return matplotlib.colors.cnames['indianred']
-        elif v in dagf_leaves:
             return matplotlib.colors.cnames['forestgreen']
+        elif v in dagf_leaves:
+            return matplotlib.colors.cnames['indianred']
         else:
             return matplotlib.colors.cnames['lightsteelblue']
 

--- a/fireworks/utilities/dagflow.py
+++ b/fireworks/utilities/dagflow.py
@@ -12,7 +12,7 @@ from igraph import Graph
 DF_TASKS = ['PyTask', 'CommandLineTask', 'ForeachTask', 'JoinDictTask',
             'JoinListTask']
 
-DEFAULT_IGRAPH_VISUAL_SYTLE = {
+DEFAULT_IGRAPH_VISUAL_STYLE = {
     "bbox": (1280, 800),
     "margin": [200, 100, 200, 100],
     "vertex_label_dist": 2,
@@ -398,7 +398,7 @@ def plot_wf(wf, view='combined', labels=False, **kwargs):
                 del vertex[key]
 
     # plotting defaults
-    visual_style = DEFAULT_IGRAPH_VISUAL_SYTLE.copy()
+    visual_style = DEFAULT_IGRAPH_VISUAL_STYLE.copy()
 
     # generic plotting defaults
     visual_style["layout"] = dagf.layout_kamada_kawai()

--- a/fireworks/utilities/dagflow.py
+++ b/fireworks/utilities/dagflow.py
@@ -242,7 +242,6 @@ class DAGFlow(Graph):
         """Returns all leaves (i.e. vertices without outgoing edges)"""
         return [i for i, v in enumerate(self.degree(mode=igraph.OUT)) if v == 0]
 
-
     def delete_ctrlflow_links(self):
         """ Deletes graph edges corresponding to control flow links """
         lst = [link.index for link in list(self.es) if link['label'] == ' ']
@@ -343,8 +342,7 @@ def plot_wf(wf, view='combined', labels=False, **kwargs):
 
     Returns:
         igraph.drawing.Plot"""
-    import igraph
-    import matplotlib
+    import matplotlib  # only needed for color-coding with favorite named colors
 
     dagf = DAGFlow.from_fireworks(wf)
     if labels:
@@ -415,6 +413,6 @@ def plot_wf(wf, view='combined', labels=False, **kwargs):
     # special treatment
     if 'layout' in kwargs and isinstance(kwargs['layout'], str):
         # tree.layout_reingold_tilford(root=[0]))
-         visual_style["layout"] = dagf.layout(kwargs['layout'])
+        visual_style["layout"] = dagf.layout(kwargs['layout'])
 
     return igraph.plot(dagf, **visual_style)


### PR DESCRIPTION
Analogous to Ivan's `to_dot` functionality, this adds a `plot_wf` function to directly generate a graph plot of a workflow. This allows to visually look at the graph directly from some interactive python session (i.e. IPython or Jupyter Notebook) before actually adding the workflow to the LaunchPad, as shown here:

![image](https://user-images.githubusercontent.com/1868344/86491160-45981800-bd6a-11ea-8293-cd59bcbe05b4.png)

To allow for looking at possibly erroneous graphs, I suggest to "weaken" assertions on the dataflow into warnings.