### PR TITLE
ENH: stoppable background tasks by simple set_stop_event method on tasks

### DIFF
--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -84,6 +84,8 @@ def background_task(btask, spec, stop_event, master_thread):
     num_launched = 0
     while not stop_event.is_set() and master_thread.isAlive():
         for task in btask.tasks:
+            if hasattr(task, 'set_stop_event'):
+                task.set_stop_event(stop_event)
             task.run_task(spec)
         if btask.sleep_time > 0:
             stop_event.wait(btask.sleep_time)


### PR DESCRIPTION
Tasks wrapped into BackgroundTask might run forever (In my particular case, I use background tasks to establish some ssh connection, i.e. for file transfer to remote machines. The ssh connection stays open as long as Fireworks itself runs, even if the connection-dependent file transfer task has finished, blocking the allocated port indefinitely). Give them an opportunity to exit gracefully by suggesting any such task to implement some `set_stop_event` method and forward the stop event if this method exists. A very simple approach.