### PR TITLE
Reorganized DAGFlow class

### DIFF
--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -189,7 +189,7 @@ def add_wf(args):
         fwf = Workflow.from_file(f)
         if args.check:
             from fireworks.utilities.dagflow import DAGFlow
-            DAGFlow.from_fireworks(fwf)
+            DAGFlow.from_fireworks(fwf).check()
         lp.add_wf(fwf)
 
 
@@ -211,10 +211,7 @@ def dump_wf(args):
 def check_wf(args):
     from fireworks.utilities.dagflow import DAGFlow
     lp = get_lp(args)
-    dagf = DAGFlow.from_fireworks(lp.get_wf_by_fw_id(args.fw_id))
-    if args.view is not None:
-        dagf.add_step_labels()
-        dagf.to_dot(args.dot_file, view=args.view)
+    DAGFlow.from_fireworks(lp.get_wf_by_fw_id(args.fw_id)).check()
 
 
 def add_wf_dir(args):
@@ -781,15 +778,9 @@ def lpad():
                               action='store_true')
     addwf_parser.set_defaults(func=add_wf, check=False)
 
-    check_wf_parser = subparsers.add_parser('check_wflow', help='validate and graph a workflow from launchpad')
+    check_wf_parser = subparsers.add_parser('check_wflow', help='check a workflow from launchpad')
     check_wf_parser.add_argument('-i', '--fw_id', type=int, help='the id of a firework from the workflow')
-    check_wf_parser.add_argument('-g', '--graph', type=str,
-                                 help='graph the workflow in DOT format; allowed views: dataflow, controlflow, '
-                                      'combined.',
-                                 dest='view', default=None)
-    check_wf_parser.add_argument('-f', '--dot_file', help='path to store the workflow graph, default: workflow.dot',
-                                 default='workflow.dot')
-    check_wf_parser.set_defaults(func=check_wf, control_flow=False, data_flow=False)
+    check_wf_parser.set_defaults(func=check_wf)
 
     get_launchdir_parser = subparsers.add_parser('get_launchdir',
                                                  help='get the directory of the most recent launch of the given fw_id.'

--- a/fireworks/utilities/dagflow.py
+++ b/fireworks/utilities/dagflow.py
@@ -7,8 +7,10 @@ __copyright__ = 'Copyright 2017, Karlsruhe Institute of Technology'
 from itertools import combinations
 from igraph import Graph
 
+
 DF_TASKS = ['PyTask', 'CommandLineTask', 'ForeachTask', 'JoinDictTask',
             'JoinListTask']
+
 
 class DAGFlow(Graph):
     """ The purpose of this class is to help construction, validation and

--- a/fireworks/utilities/tests/test_dagflow.py
+++ b/fireworks/utilities/tests/test_dagflow.py
@@ -64,7 +64,7 @@ class DAGFlowTest(unittest.TestCase):
         )
         msg = 'The workflow graph must be a DAG.: found cycles:'
         with self.assertRaises(AssertionError) as context:
-            DAGFlow.from_fireworks(wfl)
+            DAGFlow.from_fireworks(wfl).check()
         self.assertTrue(msg in str(context.exception))
 
     def test_dagflow_cut(self):
@@ -73,7 +73,7 @@ class DAGFlowTest(unittest.TestCase):
         wfl = Workflow([self.fw1, self.fw2, self.fw3], {self.fw1: self.fw2})
         msg = 'The workflow graph must be connected'
         with self.assertRaises(AssertionError) as context:
-            DAGFlow.from_fireworks(wfl)
+            DAGFlow.from_fireworks(wfl).check()
         self.assertTrue(msg in str(context.exception))
 
     def test_dagflow_link(self):
@@ -83,12 +83,12 @@ class DAGFlowTest(unittest.TestCase):
             [self.fw1, self.fw2, self.fw3],
             {self.fw1: [self.fw2, self.fw3]}
         )
-        msg = 'An input field must have exactly one source'
+        msg = 'Every input in inputs list must have exactly one source.'
         with self.assertRaises(AssertionError) as context:
-            DAGFlow.from_fireworks(wfl)
+            DAGFlow.from_fireworks(wfl).check()
         self.assertTrue(msg in str(context.exception))
 
-    def test_dagflow_input(self):
+    def test_dagflow_missing_input(self):
         """ missing input """
         from fireworks.utilities.dagflow import DAGFlow
         fw2 = Firework(
@@ -100,14 +100,14 @@ class DAGFlowTest(unittest.TestCase):
             name='pow(pow(2, 3), 4)'
         )
         wfl = Workflow([self.fw1, fw2], {self.fw1: [fw2], fw2: []})
-        msg = (r"An input field must have exactly one source', 'step', "
+        msg = (r"Every input in inputs list must have exactly one source.', 'step', "
                r"'pow(pow(2, 3), 4)', 'entity', 'exponent', 'sources', []")
         with self.assertRaises(AssertionError) as context:
-            DAGFlow.from_fireworks(wfl)
+            DAGFlow.from_fireworks(wfl).check()
         self.assertTrue(msg in str(context.exception))
 
-    def test_dagflow_output(self):
-        """ clashing inputs """
+    def test_dagflow_clashing_inputs(self):
+        """ parent firework output overwrites an input in spec """
         from fireworks.utilities.dagflow import DAGFlow
         fw2 = Firework(
             PyTask(
@@ -119,11 +119,58 @@ class DAGFlowTest(unittest.TestCase):
             spec={'exponent': 4, 'first power': 8}
         )
         wfl = Workflow([self.fw1, fw2], {self.fw1: [fw2], fw2: []})
-        msg = (r"'An input field must have exactly one source', 'step', "
+        msg = (r"'Every input in inputs list must have exactly one source.', 'step', "
                r"'pow(pow(2, 3), 4)', 'entity', 'first power', 'sources'")
         with self.assertRaises(AssertionError) as context:
-            DAGFlow.from_fireworks(wfl)
+            DAGFlow.from_fireworks(wfl).check()
         self.assertTrue(msg in str(context.exception))
+
+    def test_dagflow_race_condition(self):
+        """ two parent firework outputs overwrite each other """
+        from fireworks.utilities.dagflow import DAGFlow
+        task = PyTask(func='math.pow', inputs=['base', 'exponent'],
+                      outputs=['second power'])
+        fw1 = Firework(task, name='pow(2, 3)', spec={'base': 2, 'exponent': 3})
+        fw2 = Firework(task, name='pow(2, 3)', spec={'base': 2, 'exponent': 3})
+        wfl = Workflow([fw1, fw2, self.fw3], {fw1: [self.fw3], fw2: [self.fw3]})
+        msg = (r"'Every input in inputs list must have exactly one source.', 'step', "
+               r"'the third one', 'entity', 'second power', 'sources', [0, 1]")
+        with self.assertRaises(AssertionError) as context:
+            DAGFlow.from_fireworks(wfl).check()
+        self.assertTrue(msg in str(context.exception))
+
+    def test_dagflow_clashing_outputs(self):
+        """ subsequent task overwrites output of a task """
+        from fireworks.utilities.dagflow import DAGFlow
+
+        tasks = [PyTask(func='math.pow', inputs=['first power 1', 'exponent'],
+                        outputs=['second power']),
+                 PyTask(func='math.pow', inputs=['first power 2', 'exponent'],
+                        outputs=['second power'])]
+        fwk = Firework(tasks, spec={'exponent': 4, 'first power 1': 8,
+                                    'first power 2': 4})
+        msg = 'Several tasks may not use the same name in outputs list.'
+        with self.assertRaises(AssertionError) as context:
+            DAGFlow.from_fireworks(Workflow([fwk], {})).check()
+        self.assertTrue(msg in str(context.exception))
+
+    def test_dagflow_non_dataflow_tasks(self):
+        """ non-dataflow tasks using outputs and inputs keys do not fail """
+        from fireworks.utilities.dagflow import DAGFlow
+        from fireworks.core.firework import FireTaskBase
+
+        class NonDataFlowTask(FireTaskBase):
+            """ a firetask class for testing """
+            _fw_name = 'NonDataFlowTask'
+            required_params = ['inputs', 'outputs']
+            def run_task(self, fw_spec):
+                pass
+
+        task = NonDataFlowTask(inputs=['first power', 'exponent'],
+                               outputs=['second power'])
+        fw2 = Firework(task, spec={'exponent': 4, 'first power': 8})
+        wfl = Workflow([self.fw1, fw2], {self.fw1: [fw2], fw2: []})
+        DAGFlow.from_fireworks(wfl).check()
 
     def test_dagflow_view(self):
         """ visualize the workflow graph """


### PR DESCRIPTION
Solves issue https://github.com/materialsproject/fireworks/issues/411. Only assertions have not been replaced with specific exceptions. Though the issued `AssertionError` can still be trapped by calling functions (see examples in the tests). 