### PR TITLE
ENH: Joint queries on Fireworks and Workflows from command line

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -770,7 +770,7 @@ class LaunchPad(FWSerializable):
 
         return wf_ids
 
-    def get_fws_ids_in_wfs(self, wf_query=None, fw_query=None, sort=None,
+    def get_fw_ids_in_wfs(self, wf_query=None, fw_query=None, sort=None,
                            limit=0, count_only=False, launches_mode=False):
         """
         Return all fw ids that match fw_query within workflows that match wf_query.
@@ -821,6 +821,8 @@ class LaunchPad(FWSerializable):
 
         if count_only:
             aggregation.append({'$count': 'count'})
+            self.m_logger.debug("Aggregation '{}'.".format(aggregation))
+
             cursor = self.workflows.aggregate(aggregation)
             return list(cursor)[0]['count']
 
@@ -829,9 +831,10 @@ class LaunchPad(FWSerializable):
 
         aggregation.append({'$project': {'fw_id': True, '_id': False}})
 
-        if limit is not None:
+        if limit is not None and limit > 0:
             aggregation.append({'$limit': limit})
 
+        self.m_logger.debug("Aggregation '{}'.".format(aggregation))
         cursor = self.workflows.aggregate(aggregation)
         return [fw["fw_id"] for fw in cursor]
 

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -771,7 +771,7 @@ class LaunchPad(FWSerializable):
         return wf_ids
 
     def get_fw_ids_in_wfs(self, wf_query=None, fw_query=None, sort=None,
-                           limit=0, count_only=False, launches_mode=False):
+                          limit=0, count_only=False, launches_mode=False):
         """
         Return all fw ids that match fw_query within workflows that match wf_query.
 

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -832,25 +832,25 @@ def lpad():
     # for using fw- and wf-specific options on one command line, distinguish by prefix fw and wf
     # prefix short one-dash options with 'wf', i.e. '-i' -> '-wfi'
     # prefix long two-dash options with 'wf_', i.e. '--fw_id' -> '--wf_fw_id'
-    wf_prefixed_fw_id_args = [re.sub('^-([^-].*)$','-wf\\1',s) for s in fw_id_args]
-    wf_prefixed_fw_id_args = [re.sub('^--(.*)$','--wf_\\1',s) for s in wf_prefixed_fw_id_args]
+    wf_prefixed_fw_id_args = [re.sub('^-([^-].*)$', '-wf\\1', s) for s in fw_id_args]
+    wf_prefixed_fw_id_args = [re.sub('^--(.*)$', '--wf_\\1', s) for s in wf_prefixed_fw_id_args]
 
-    wf_prefixed_state_args = [re.sub('^-([^-].*)$','-wf\\1',s) for s in state_args]
-    wf_prefixed_state_args = [re.sub('^--(.*)$','--wf_\\1',s) for s in wf_prefixed_state_args]
+    wf_prefixed_state_args = [re.sub('^-([^-].*)$', '-wf\\1', s) for s in state_args]
+    wf_prefixed_state_args = [re.sub('^--(.*)$', '--wf_\\1', s) for s in wf_prefixed_state_args]
 
-    wf_prefixed_query_args = [re.sub('^-([^-].*)$','-wf\\1',s) for s in query_args]
-    wf_prefixed_query_args = [re.sub('^--(.*)$','--wf_\\1',s) for s in wf_prefixed_query_args]
+    wf_prefixed_query_args = [re.sub('^-([^-].*)$', '-wf\\1', s) for s in query_args]
+    wf_prefixed_query_args = [re.sub('^--(.*)$', '--wf_\\1', s) for s in wf_prefixed_query_args]
 
     # prefix short one-dash options with 'fw', i.e. '-i' -> '-fwi'
     # prefix long two-dash options with 'fw_', i.e. '--fw_id' -> '--fw_fw_id'
-    fw_prefixed_fw_id_args = [re.sub('^-([^-].*)$','-fw\\1',s) for s in fw_id_args]
-    fw_prefixed_fw_id_args = [re.sub('^--(.*)$','--fw_\\1',s) for s in fw_prefixed_fw_id_args]
+    fw_prefixed_fw_id_args = [re.sub('^-([^-].*)$', '-fw\\1', s) for s in fw_id_args]
+    fw_prefixed_fw_id_args = [re.sub('^--(.*)$', '--fw_\\1', s) for s in fw_prefixed_fw_id_args]
 
-    fw_prefixed_state_args = [re.sub('^-([^-].*)$','-fw\\1',s) for s in state_args]
-    fw_prefixed_state_args = [re.sub('^--(.*)$','--fw_\\1',s) for s in fw_prefixed_state_args]
+    fw_prefixed_state_args = [re.sub('^-([^-].*)$', '-fw\\1', s) for s in state_args]
+    fw_prefixed_state_args = [re.sub('^--(.*)$', '--fw_\\1', s) for s in fw_prefixed_state_args]
 
-    fw_prefixed_query_args = [re.sub('^-([^-].*)$','-fw\\1',s) for s in query_args]
-    fw_prefixed_query_args = [re.sub('^--(.*)$','--fw_\\1',s) for s in fw_prefixed_query_args]
+    fw_prefixed_query_args = [re.sub('^-([^-].*)$', '-fw\\1', s) for s in query_args]
+    fw_prefixed_query_args = [re.sub('^--(.*)$', '--fw_\\1', s) for s in fw_prefixed_query_args]
 
     # filter all long options, i.e. '--fw_id' and strip off preceding '--'
     fw_id_options = [re.sub('^--(.*)$', '\\1', opt)
@@ -960,11 +960,11 @@ def lpad():
     get_fw_in_wf_parser.add_argument(*qid_args, **qid_kwargs)
     get_fw_in_wf_parser.add_argument(*disp_args, **disp_kwargs)
     get_fw_in_wf_parser.add_argument('-m', '--max', help='limit results', default=0,
-                               type=int)
+                                     type=int)
     get_fw_in_wf_parser.add_argument('--sort', help='Sort results',
-                               choices=["created_on", "updated_on"])
+                                     choices=["created_on", "updated_on"])
     get_fw_in_wf_parser.add_argument('--rsort', help='Reverse sort results',
-                               choices=["created_on", "updated_on"])
+                                     choices=["created_on", "updated_on"])
     get_fw_in_wf_parser.set_defaults(func=get_fws_in_wfs)
 
     trackfw_parser = subparsers.add_parser('track_fws', help='Track FireWorks')


### PR DESCRIPTION
This is another loose suggestion for extension: Often, I want to quickly submit a joint query between Fireworks and Workflows, i.e. get an overview on all FIZZLED Fireworks in a particular workflow. Here is an extension to the Launchpad and its command line interface to avoid the "detour" via direct MongoDB queries. One particular consideration for discussion would be how to distinguish between CLI options aimed at selecting Fireworks query and such aimed at selecting Workflows. I chose options prefixed with 'fw' and 'wf' respectively here, i.e.

    lpad get_fws_in_wflows -wfi 38710 -fwq '{"state":"FIZZLED","name":{"$regex":"gmx_mdrun$"}}' -d all

would yield all Fireworks matching the 'fwq' query within the Workflow identified by 'wfi'.