### PR TITLE
Don't fork a process to start the web server -- Fix #416

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,6 @@ fw_tutorials/firetask/addition_task2.py
 fw_tutorials/firetask/words.txt
 
 my_launchpad.yaml
+.python-version
+FW.json
 .DS_Store

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -535,6 +535,13 @@ def set_priority(args):
     lp.m_logger.info("Finished setting priorities of {} FWs".format(len(fw_ids)))
 
 
+def _open_webbrowser(url):
+    """Open a web browser after a delay to give the web server more startup time."""
+    import webbrowser
+    time.sleep(2)
+    webbrowser.open(url)
+
+
 def webgui(args):
     from fireworks.flask_site.app import app
     app.lp = get_lp(args)
@@ -554,14 +561,11 @@ def webgui(args):
             app.BASE_Q_WF["state"] = app.BASE_Q["state"]
 
     if not args.server_mode:
-        from multiprocessing import Process
-        p1 = Process(
-            target=app.run,
-            kwargs={"host": args.host, "port": args.port, "debug": args.debug})
+        from threading import Thread
+        url = "http://{}:{}".format(args.host, args.port)
+        p1 = Thread(target=_open_webbrowser, args=(url,))
         p1.start()
-        import webbrowser
-        time.sleep(2)
-        webbrowser.open("http://{}:{}".format(args.host, args.port))
+        app.run(host=args.host, port=args.port, debug=args.debug)
         p1.join()
     else:
         try:


### PR DESCRIPTION
Fix the `TypeError: cannot pickle '_thread.lock' object` Issue #416 by not spawning a webserver process.

It could just call `webbrowser.open()` without additional parallelization, but this spawns a thread to call it to preserve the delay that gives the web server more time to get ready to serve pages.

I tested this on a Mac with Chrome, both in the cases where Chrome was already running and not. I didn't test other OSs or browsers, but it's using stock Python APIs. I tested this in Python 3.8.6. It should be fine in other Python releases, although the Python docs listed the `threading` module under "Optional Operating System Services" in Python 2.7 -- it's certainly present in the Mac Python 2.7.16.

Note: When `webbrowser.open(url)` needs to launch Chrome, Chrome opens the Fireworks `url` in a new window then restores its previous tabs in another window right on top of the Fireworks window, kind of hiding it.

(This branch forked from the `v1.9.6` tag since I don't know the state of the unreleased changes in master.)