### PR TITLE
Functionality to optionally checkpoint Fireworks in response to signals

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -209,8 +209,8 @@ class Firework(FWSerializable):
     A Firework is a workflow step and might be contain several Firetasks.
     """
     STATE_RANKS = {'ARCHIVED': -2, 'FIZZLED': -1, 'DEFUSED': 0, 'PAUSED': 0,
-                   'WAITING': 1, 'READY': 2, 'RESERVED': 3, 'RUNNING': 4,
-                   'COMPLETED': 5, 'CHECKPOINTED': 6}
+                   'WAITING': 1, 'READY': 2, 'RESERVED': 3, 'RUNNING': 4, 
+                   'CHECKPOINTED': 5, 'COMPLETED': 6}
 
     # note: if you modify this signature, you must also modify LazyFirework
     def __init__(self, tasks, spec=None, name=None, launches=None, archived_launches=None,

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -73,6 +73,10 @@ class FiretaskBase(defaultdict, FWSerializable):
                             self.__class__, k, allowed_params))
 
     @abc.abstractmethod
+    def checkpoint(self, signum, stack):
+        raise NotImplementedError("You must have a checkpoint implemented!")
+
+    @abc.abstractmethod
     def run_task(self, fw_spec):
         """
         This method gets called when the Firetask is run. It can take in a
@@ -204,10 +208,9 @@ class Firework(FWSerializable):
     """
     A Firework is a workflow step and might be contain several Firetasks.
     """
-
     STATE_RANKS = {'ARCHIVED': -2, 'FIZZLED': -1, 'DEFUSED': 0, 'PAUSED': 0,
                    'WAITING': 1, 'READY': 2, 'RESERVED': 3, 'RUNNING': 4,
-                   'COMPLETED': 5}
+                   'COMPLETED': 5, 'CHECKPOINTED': 6}
 
     # note: if you modify this signature, you must also modify LazyFirework
     def __init__(self, tasks, spec=None, name=None, launches=None, archived_launches=None,

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -209,7 +209,7 @@ class Firework(FWSerializable):
     A Firework is a workflow step and might be contain several Firetasks.
     """
     STATE_RANKS = {'ARCHIVED': -2, 'FIZZLED': -1, 'DEFUSED': 0, 'PAUSED': 0,
-                   'WAITING': 1, 'READY': 2, 'RESERVED': 3, 'RUNNING': 4, 
+                   'WAITING': 1, 'READY': 2, 'RESERVED': 3, 'RUNNING': 4,
                    'CHECKPOINTED': 5, 'COMPLETED': 6}
 
     # note: if you modify this signature, you must also modify LazyFirework

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -1100,7 +1100,7 @@ class LaunchPad(FWSerializable):
             self.m_logger.error(
                 'No checkpoint-able (RUNNING) Firework exists with fw_id: {}'.format(
                     fw_id))
-        return f                    
+        return f
 
     def defuse_wf(self, fw_id, defuse_all_states=True):
         """
@@ -1125,7 +1125,7 @@ class LaunchPad(FWSerializable):
         wf = self.get_wf_by_fw_id_lzyfw(fw_id)
         for fw in wf.fws:
             if fw.state not in ["COMPLETED", "FIZZLED", "DEFUSED"]:
-                self.pause_fw(fw.fw_id)                
+                self.pause_fw(fw.fw_id)
 
     def reignite_wf(self, fw_id):
         """

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -1107,6 +1107,26 @@ class LaunchPad(FWSerializable):
             if fw.state not in ["COMPLETED", "FIZZLED", "DEFUSED"]:
                 self.pause_fw(fw.fw_id)
 
+    def checkpoint_fw(self, fw_id):
+        """
+        Given the firework id, mark firework as checkpointed and refresh the workflow
+
+        Args:
+            fw_id(int): firework id
+        """
+        allowed_states = ['RUNNING']
+        f = self.fireworks.find_one_and_update(
+            {'fw_id': fw_id, 'state': {'$in': allowed_states}},
+            {'$set': {'state': 'CHECKPOINTED',
+                      'updated_on': datetime.datetime.utcnow()}})
+        if f:
+            self.m_logger.info('Checkpointed FireWork')
+        if not f:
+            self.m_logger.error(
+                'No pausable (RUNNING) Firework exists with fw_id: {}'.format(
+                    fw_id))
+        return f            
+
     def reignite_wf(self, fw_id):
         """
          Reignite the workflow containing the given firework id.

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -1082,18 +1082,18 @@ class LaunchPad(FWSerializable):
             self._refresh_wf(fw_id)
         return f
 
-    def checkpoint_fw(self, fw_id):
+    def checkpoint_launch(self, fw_id):
         """
-        Given the firework id, mark firework as checkpointed and refresh the workflow
+        Given the firework id, mark launch as checkpointed and refresh the workflow
 
         Args:
             fw_id(int): firework id
         """
-        allowed_states = ['RUNNING']
-        f = self.fireworks.find_one_and_update(
-            {'fw_id': fw_id, 'state': {'$in': allowed_states}},
+        f = self.launches.find_one_and_update(
+            {'fw_id': fw_id, 'state': 'RUNNING'},
             {'$set': {'state': 'CHECKPOINTED',
                       'updated_on': datetime.datetime.utcnow()}})
+        self._refresh_wf(fw_id)
         if f:
             self.m_logger.info('Checkpointed FireWork')
         if not f:

--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -260,7 +260,7 @@ class Rocket:
                     t.fworker = self.fworker
 
                 try:
-                    if getattr(t, 'checkpoint', None) and callable(t.checkpoint):
+                    if getattr(t, 'checkpoint') and callable(t.checkpoint):
                         signal.signal(signal.SIGUSR1, t.checkpoint)
                     m_action = t.run_task(my_spec)
                 except BaseException as e:

--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -262,7 +262,6 @@ class Rocket:
                 try:
                     if getattr(t, 'checkpoint', None) and callable(t.checkpoint):
                         signal.signal(signal.SIGUSR1, t.checkpoint)
-                    l_logger.log(logging.INFO,'PID = {0}'.format(os.getpid()))
                     m_action = t.run_task(my_spec)
                 except BaseException as e:
                     traceback.print_exc()

--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -259,6 +259,7 @@ class Rocket:
                     t.fworker = self.fworker
 
                 try:
+                    t.f_logger = l_logger
                     m_action = t.run_task(my_spec)
                 except BaseException as e:
                     traceback.print_exc()

--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -259,7 +259,6 @@ class Rocket:
                     t.fworker = self.fworker
 
                 try:
-                    t.f_logger = l_logger
                     m_action = t.run_task(my_spec)
                 except BaseException as e:
                     traceback.print_exc()

--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -21,6 +21,7 @@ import glob
 import shutil
 import pdb
 import distutils.dir_util
+import signal
 from monty.io import zopen
 from monty.serialization import loadfn, dumpfn
 
@@ -259,6 +260,9 @@ class Rocket:
                     t.fworker = self.fworker
 
                 try:
+                    if getattr(t, 'checkpoint', None) and callable(t.checkpoint):
+                        signal.signal(signal.SIGUSR1, t.checkpoint)
+                    l_logger.log(logging.INFO,'PID = {0}'.format(os.getpid()))
                     m_action = t.run_task(my_spec)
                 except BaseException as e:
                     traceback.print_exc()

--- a/fireworks/user_objects/firetasks/script_task.py
+++ b/fireworks/user_objects/firetasks/script_task.py
@@ -30,7 +30,7 @@ class ScriptTask(FiretaskBase):
             if launchpad_passed:
                 message = f'Checkpointing ScriptTask [Firework ID: {self.fw_id}]'
                 launchpad_passed.m_logger.log(logging.INFO, message)
-                self.launchpad.checkpoint_fw(self.fw_id)
+                self.launchpad.checkpoint_launch(self.fw_id)
         except AttributeError as e:
             if launchpad_passed:
                 error = f"""Checkpointing error ScriptTask,

--- a/fireworks/user_objects/firetasks/script_task.py
+++ b/fireworks/user_objects/firetasks/script_task.py
@@ -24,19 +24,27 @@ class ScriptTask(FiretaskBase):
     _fw_name = 'ScriptTask'
 
     def checkpoint(self, signum, stack):
+        self.checkpoint_called = True
         try:
-            self.f_logger.log(logging.INFO, 
-                f'ScriptTask.checkpoint Firework with ID = {self.fw_id}')
+            if getattr(self,'f_logger', None):
+                self.f_logger.log(logging.INFO, 
+                    f'ScriptTask.checkpoint Firework with ID = {self.fw_id}')
             # Use the included launchpad object to 
             # change the status of the FireWork to "CHECKPOINTED":
-            self.launchpad.checkpoint_fw(self.fw_id)
+            if getattr(self,'launchpad', None):
+                self.launchpad.checkpoint_fw(self.fw_id)
         except Exception as e:
-            self.f_logger.log(logging.ERROR, str(e))
+            if getattr(self,'f_logger',None):
+                self.f_logger.log(logging.ERROR, str(e))
+            else:
+                print(str(e))
 
     def run_task(self, fw_spec):
+        self.checkpoint_called = False
         signal.signal(signal.SIGUSR1, self.checkpoint)
-        self.f_logger.log(logging.INFO, 
-            f'ScriptTask.run_task PID = {os.getpid()}')
+        if getattr(self,'f_logger',None):
+            self.f_logger.log(logging.INFO, 
+                f'ScriptTask.run_task PID = {os.getpid()}')
         if self.get('use_global_spec'):
             self._load_params(fw_spec)
         else:

--- a/fireworks/user_objects/firetasks/script_task.py
+++ b/fireworks/user_objects/firetasks/script_task.py
@@ -28,7 +28,7 @@ class ScriptTask(FiretaskBase):
         launchpad_passed = getattr(self, 'launchpad', None)
         try:
             if launchpad_passed:
-                message = f'Checkpointing ScriptTask [Firework ID: {self.fw_id}'
+                message = f'Checkpointing ScriptTask [Firework ID: {self.fw_id}]'
                 launchpad_passed.m_logger.log(logging.INFO, message)
                 self.launchpad.checkpoint_fw(self.fw_id)
         except AttributeError as e:
@@ -39,7 +39,6 @@ class ScriptTask(FiretaskBase):
 
     def run_task(self, fw_spec):
         self.checkpoint_called = False
-        signal.signal(signal.SIGUSR1, self.checkpoint)
         if self.get('use_global_spec'):
             self._load_params(fw_spec)
         else:

--- a/fireworks/user_objects/firetasks/script_task.py
+++ b/fireworks/user_objects/firetasks/script_task.py
@@ -25,7 +25,7 @@ class ScriptTask(FiretaskBase):
 
     def checkpoint(self, signum, stack):
         self.checkpoint_called = True
-        launchpad_passed = getattr(self,'launchpad', None)
+        launchpad_passed = getattr(self, 'launchpad', None)
         try:
             if launchpad_passed:
                 message = f'Checkpointing ScriptTask [Firework ID: {self.fw_id}'
@@ -33,10 +33,9 @@ class ScriptTask(FiretaskBase):
                 self.launchpad.checkpoint_fw(self.fw_id)
         except AttributeError as e:
             if launchpad_passed:
-                launchpad_passed.m_logger.log(logging.ERROR,
-                    f"""Checkpointing error ScriptTask, 
-                            details [{str(e)}]""")
-                self.f_logger.log(logging.ERROR, str(e))
+                error = f"""Checkpointing error ScriptTask,
+                          details [{str(e)}]"""
+                launchpad_passed.m_logger.log(logging.ERROR, error)
 
     def run_task(self, fw_spec):
         self.checkpoint_called = False

--- a/fireworks/user_objects/firetasks/script_task.py
+++ b/fireworks/user_objects/firetasks/script_task.py
@@ -50,6 +50,8 @@ class ScriptTask(FiretaskBase):
         return self._run_task_internal(fw_spec, stdin)
 
     def _run_task_internal(self, fw_spec, stdin):
+        def ignore_SIGUSR1():
+            signal.signal(signal.SIGUSR1, signal.SIG_IGN)
         # run the program
         stdout = subprocess.PIPE if self.store_stdout or self.stdout_file else None
         stderr = subprocess.PIPE if self.store_stderr or self.stderr_file else None
@@ -58,7 +60,8 @@ class ScriptTask(FiretaskBase):
             p = subprocess.Popen(
                 s, executable=self.shell_exe, stdin=stdin,
                 stdout=stdout, stderr=stderr,
-                shell=self.use_shell)
+                shell=self.use_shell,
+                preexec_fn=ignore_SIGUSR1)
 
             # communicate in the standard in and get back the standard out and returncode
             if self.stdin_key:

--- a/fireworks/user_objects/firetasks/tests/test_script_task.py
+++ b/fireworks/user_objects/firetasks/tests/test_script_task.py
@@ -6,6 +6,7 @@ import unittest
 import os
 import signal
 from fireworks.user_objects.firetasks.script_task import ScriptTask, PyTask
+import pytest
 
 __author__ = "Shyue Ping Ong, Bharat Medasani"
 __copyright__ = "Copyright 2012, The Materials Project"
@@ -37,11 +38,14 @@ class ScriptTaskTest(unittest.TestCase):
             os.remove('hello.txt')
         s = ScriptTask({'script': 'echo "hello checkpointed world";',
                         'stdout_file': 'hello.txt'})
+        # Mock rocket behavior:
+        signal.signal(signal.SIGUSR1, s.checkpoint)        
         s.run_task({})
         assert not s.checkpoint_called
         os.kill(os.getpid(), signal.SIGUSR1)
         assert s.checkpoint_called
         self.assertTrue(os.path.exists('hello.txt'))
+        os.remove('hello.txt')
 
     def test_checkpointing_scripttask_unsignaled(self):
         if os.path.exists('hello.txt'):

--- a/fireworks/user_objects/firetasks/tests/test_script_task.py
+++ b/fireworks/user_objects/firetasks/tests/test_script_task.py
@@ -6,7 +6,6 @@ import unittest
 import os
 import signal
 from fireworks.user_objects.firetasks.script_task import ScriptTask, PyTask
-import pytest
 
 __author__ = "Shyue Ping Ong, Bharat Medasani"
 __copyright__ = "Copyright 2012, The Materials Project"


### PR DESCRIPTION
_This is work which was coordinated with @mkhorton and @shreddd._

## Changes:
- Adding new `checkpoint` abstract method to `FiretaskBase`.
- Adding new `CHECKPOINTED` status to `Firework.STATE_RANKS`. 
- Implementing a new `checkpoint_fw` to `launchpad` which looks for `RUNNING` Fireworks that match a given ID and changes their status to `CHECKPOINTED`.
- Implementing `checkpoint` in `ScriptTask` which depends on a `Launchpad` object being passed to the ScriptTask (this can currently be done by passing `_add_launchpad_and_fw_id` through the YAML config). 