### PR TITLE
Fix syntax warning over comparison of literals using is.

### DIFF
--- a/fireworks/features/fw_report.py
+++ b/fireworks/features/fw_report.py
@@ -143,10 +143,10 @@ class FWReport:
         bottom = [0] * len(results)
         for state in states:
             if any(data[state]):
-                if style is 'bar':
+                if style == 'bar':
                     ax.bar(range(len(bottom)), data[state], bottom=bottom,
                            color=state_to_color[state], label=state)
-                elif style is 'fill':
+                elif style == 'fill':
                     ax.fill_between(range(len(bottom)),
                                     bottom, [x + y for x, y in
                                              zip(bottom, data[state])],

--- a/fireworks/utilities/dict_mods.py
+++ b/fireworks/utilities/dict_mods.py
@@ -78,7 +78,7 @@ class DictMods(object):
     def __init__(self):
         self.supported_actions = {}
         for i in dir(self):
-            if (not re.match('__\w+__', i)) and callable(getattr(self, i)):
+            if (not re.match(r'__\w+__', i)) and callable(getattr(self, i)):
                 self.supported_actions["_" + i] = getattr(self, i)
 
     @staticmethod


### PR DESCRIPTION
Fixes below warnings in Python 3.8

```
find . -iname '*.py' | xargs -P4 -I{} python3.8 -Wall -m py_compile {}          
./fireworks/features/fw_report.py:146: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if style is 'bar':
./fireworks/features/fw_report.py:149: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif style is 'fill':
./fireworks/utilities/dict_mods.py:81: DeprecationWarning: invalid escape sequence \w
  if (not re.match('__\w+__', i)) and callable(getattr(self, i)):
```