### PR TITLE
add gpu option to slurm template

### DIFF
--- a/fireworks/user_objects/queue_adapters/SLURM_template.txt
+++ b/fireworks/user_objects/queue_adapters/SLURM_template.txt
@@ -7,6 +7,7 @@
 #SBATCH --core-spec=$${core_spec}
 #SBATCH --exclude=$${exclude_nodes}
 #SBATCH --cpus-per-task=$${cpus_per_task}
+#SBATCH --gpus-per-task=$${gpus_per_task}
 #SBATCH --gres=$${gres}
 #SBATCH --qos=$${qos}
 #SBATCH --time=$${walltime}


### PR DESCRIPTION
Hi FireWorks developers,

This PR adds a GPU option to the SLURM template

I'm at NERSC and thinking about running FireWorks on Perlmutter. I wanted to make it easier for users to do this without manually editing the SLURM template themselves.

Best regards,
Laurie
