### PR TITLE
add mpworkshop's wf_to_graph + SSOT for state_to_color

### DIFF
--- a/fireworks/features/fw_report.py
+++ b/fireworks/features/fw_report.py
@@ -11,6 +11,17 @@ __author__ = 'Anubhav Jain <ajain@lbl.gov>'
 # indices for parsing a datetime string in format 2015-09-28T12:00:07.772058
 DATE_KEYS = {"years": 4, "months": 7, "days": 10, "hours": 13, "minutes": 16}
 
+state_to_color = {
+    "RUNNING": "#F4B90B",
+    "WAITING": "#1F62A2",
+    "FIZZLED": "#DB0051",
+    "READY": "#2E92F2",
+    "COMPLETED": "#24C75A",
+    "RESERVED": "#BB8BC1",
+    "ARCHIVED": "#7F8287",
+    "DEFUSED": "#B7BCC3",
+    "PAUSED": "#FFCFCA"
+}
 
 class FWReport:
     def __init__(self, lpad):
@@ -120,16 +131,6 @@ class FWReport:
             matplotlib plot module
         """
         results = self.get_stats(coll, interval, num_intervals, **kwargs)
-        state_to_color = {"RUNNING": "#F4B90B",
-                          "WAITING": "#1F62A2",
-                          "FIZZLED": "#DB0051",
-                          "READY": "#2E92F2",
-                          "COMPLETED": "#24C75A",
-                          "RESERVED": "#BB8BC1",
-                          "ARCHIVED": "#7F8287",
-                          "DEFUSED": "#B7BCC3",
-                          "PAUSED": "#FFCFCA"
-                          }
         states = states or state_to_color.keys()
 
         from matplotlib.figure import Figure

--- a/fireworks/features/fw_report.py
+++ b/fireworks/features/fw_report.py
@@ -2,8 +2,8 @@ from __future__ import division
 
 from collections import OrderedDict
 from datetime import datetime
-from dateutil.relativedelta import relativedelta
 
+from dateutil.relativedelta import relativedelta
 from fireworks import Firework
 
 __author__ = 'Anubhav Jain <ajain@lbl.gov>'
@@ -22,6 +22,7 @@ state_to_color = {
     "DEFUSED": "#B7BCC3",
     "PAUSED": "#FFCFCA"
 }
+
 
 class FWReport:
     def __init__(self, lpad):

--- a/fireworks/flask_site/app.py
+++ b/fireworks/flask_site/app.py
@@ -15,6 +15,7 @@ from fireworks.core.launchpad import LaunchPad
 from fireworks.fw_config import WEBSERVER_PERFWARNINGS
 import fireworks.flask_site.helpers as fwapp_util
 from fireworks.flask_site.util import jsonify
+from fireworks.features.fw_report import state_to_color
 
 app = Flask(__name__)
 app.use_reloader = True
@@ -186,16 +187,6 @@ def workflow_json(wf_id):
         raise ValueError("Invalid fw_id: {}".format(wf_id))
 
     # TODO: modify so this doesn't duplicate the .css file that contains the same colors
-    state_to_color = {"RUNNING": "#F4B90B",
-                      "WAITING": "#1F62A2",
-                      "FIZZLED": "#DB0051",
-                      "READY": "#2E92F2",
-                      "COMPLETED": "#24C75A",
-                      "RESERVED": "#BB8BC1",
-                      "ARCHIVED": "#7F8287",
-                      "DEFUSED": "#B7BCC3",
-                      "PAUSED": "#FFCFCA"
-                      }
 
     wf = app.lp.workflows.find_one({'nodes': wf_id})
     fireworks = list(app.lp.fireworks.find({"fw_id": {"$in": wf["nodes"]}},

--- a/fireworks/utilities/dagflow.py
+++ b/fireworks/utilities/dagflow.py
@@ -6,11 +6,12 @@ __copyright__ = 'Copyright 2017, Karlsruhe Institute of Technology'
 
 import warnings
 from itertools import combinations
+
 import igraph
+from fireworks import Workflow
+from fireworks.features.fw_report import state_to_color
 from igraph import Graph
 from monty.dev import requires
-from fireworks import Firework, Workflow
-from fireworks.features.fw_report import state_to_color
 
 try:
     from graphviz import Digraph
@@ -30,6 +31,7 @@ DEFAULT_IGRAPH_VISUAL_STYLE = {
 # any other blue
 try:
     import matplotlib
+
     # only needed for color-coding with favorite named colors, not imported
     # in top level as matplotlib is no Fireworks requirement.
 
@@ -434,9 +436,8 @@ def plot_wf(wf, view='combined', labels=False, **kwargs):
     return igraph.plot(dagf, **visual_style)
 
 
-
 @requires(
-    graphviz, 
+    graphviz,
     "graphviz package required for wf_to_graph.\n"
     "Follow the installation instructions here: https://github.com/xflr6/graphviz"
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-
-from setuptools import setup, find_packages
+import logging
+import multiprocessing  # AJ: for some reason this is needed to not have "python setup.py test" freak out
 import os
-import multiprocessing, logging  # AJ: for some reason this is needed to not have "python setup.py test" freak out
 
+from setuptools import find_packages, setup
 
 __author__ = "Anubhav Jain"
 __copyright__ = "Copyright 2013, The Materials Project"
@@ -39,7 +39,8 @@ if __name__ == "__main__":
                         'newt': ['requests>=2.01'],
                         'daemon_mode':['fabric>=2.3.1'],
                         'flask-plotting': ['matplotlib>=2.0.1'],
-                        'workflow-checks': ['python-igraph>=0.7.1']},
+                        'workflow-checks': ['python-igraph>=0.7.1'],
+                        'graph-plotting': ['graphviz']},
         classifiers=['Programming Language :: Python',
                      'Development Status :: 5 - Production/Stable',
                      'Intended Audience :: Science/Research',


### PR DESCRIPTION
This PR adds `wf_to_graph` [from here](https://git.io/JO6L8) to `fireworks/utilities/dagflow.py` as discussed in [atomate#638](https://github.com/hackingmaterials/atomate/issues/638#issuecomment-824273303).

It also refactors `state_to_color` to have a single source of truth in `fireworks/features/fw_report.py`. Let me know if this is unwanted or should be placed somewhere else.