### PR TITLE
Lastephey/update slurm template

### DIFF
--- a/fireworks/user_objects/queue_adapters/SLURM_template.txt
+++ b/fireworks/user_objects/queue_adapters/SLURM_template.txt
@@ -8,7 +8,10 @@
 #SBATCH --exclude=$${exclude_nodes}
 #SBATCH --cpus-per-task=$${cpus_per_task}
 #SBATCH --gpus-per-task=$${gpus_per_task}
+#SBATCH --gpus-per-node=$${gpus_per_node}
 #SBATCH --gres=$${gres}
+#SBATCH --gpus=$${gpus}
+#SBATCH --gpu-bind=${gpu-bind}
 #SBATCH --qos=$${qos}
 #SBATCH --time=$${walltime}
 #SBATCH --time-min=$${time_min}
@@ -24,6 +27,8 @@
 #SBATCH --mem-per-cpu=$${mem_per_cpu}
 #SBATCH --mail-type=$${mail_type}
 #SBATCH --mail-user=$${mail_user}
+#SBATCH --image=$${image}
+#SBATCH --volume=$${volume}
 
 
 $${pre_rocket}

--- a/fireworks/user_objects/queue_adapters/SLURM_template.txt
+++ b/fireworks/user_objects/queue_adapters/SLURM_template.txt
@@ -11,7 +11,7 @@
 #SBATCH --gpus-per-node=$${gpus_per_node}
 #SBATCH --gres=$${gres}
 #SBATCH --gpus=$${gpus}
-#SBATCH --gpu-bind=${gpu-bind}
+#SBATCH --gpu-bind=$${gpu-bind}
 #SBATCH --qos=$${qos}
 #SBATCH --time=$${walltime}
 #SBATCH --time-min=$${time_min}


### PR DESCRIPTION
Dear FireWorks developers,

This PR contains some updates to the `SLURM_template.txt` with NERSC users in mind.

We add two flags `--image` and `--volume` to enable users to run Shifter containers in FireWorks jobs. (Please see here for more info about Shifter: https://docs.nersc.gov/development/shifter/how-to-use/)

We add several more flags for more flexible GPU configuration, including `--gpus` and `--gpu-bind`.

If you have any questions or concerns please let me know.

Thank you,
Laurie