### PR TITLE
pymongo count() --> count_documents()

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -342,7 +342,7 @@ class LaunchPad(FWSerializable):
         m_password = datetime.datetime.now().strftime('%Y-%m-%d')
 
         if password == m_password or (
-                not require_password and self.workflows.count() <= max_reset_wo_password):
+                not require_password and self.workflows.count_documents() <= max_reset_wo_password):
             self.fireworks.delete_many({})
             self.launches.delete_many({})
             self.workflows.delete_many({})
@@ -359,7 +359,7 @@ class LaunchPad(FWSerializable):
             raise ValueError(
                 "Password check cannot be overridden since the size of DB ({} workflows) "
                 "is greater than the max_reset_wo_password parameter ({}).".format(
-                    self.fireworks.count(),
+                    self.fireworks.count_documents(),
                     max_reset_wo_password))
         else:
             raise ValueError(
@@ -1444,8 +1444,8 @@ class LaunchPad(FWSerializable):
 
                 # for offline runs, you want to forget about the run
                 # see: https://groups.google.com/forum/#!topic/fireworkflows/oimFmE5tZ4E
-                offline_run = self.offline_runs.find(
-                    {"launch_id": lid, "deprecated": False}).count() > 0
+                offline_run = self.offline_runs.count_documents(
+                    {"launch_id": lid, "deprecated": False}) > 0
                 if offline_run:
                     self.forget_offline(lid, launch_mode=True)
 

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -342,7 +342,7 @@ class LaunchPad(FWSerializable):
         m_password = datetime.datetime.now().strftime('%Y-%m-%d')
 
         if password == m_password or (
-                not require_password and self.workflows.count_documents() <= max_reset_wo_password):
+                not require_password and self.workflows.count_documents({}) <= max_reset_wo_password):
             self.fireworks.delete_many({})
             self.launches.delete_many({})
             self.workflows.delete_many({})
@@ -359,7 +359,7 @@ class LaunchPad(FWSerializable):
             raise ValueError(
                 "Password check cannot be overridden since the size of DB ({} workflows) "
                 "is greater than the max_reset_wo_password parameter ({}).".format(
-                    self.fireworks.count_documents(),
+                    self.fireworks.count_documents({}),
                     max_reset_wo_password))
         else:
             raise ValueError(

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -54,7 +54,7 @@ class AuthenticationTest(unittest.TestCase):
         with self.assertRaises(OperationFailure):
             lp = LaunchPad(name="admin", username="myuser",
                            password="mypassword", authsource="admin")
-            lp.db.collection.count()
+            lp.db.collection.count_documents()
 
     def test_authenticating_to_users_db(self):
         """A user should be able to authenticate against a database that they
@@ -62,7 +62,7 @@ class AuthenticationTest(unittest.TestCase):
         """
         lp = LaunchPad(name="not_the_admin_db", username="myuser",
                        password="mypassword", authsource="not_the_admin_db")
-        lp.db.collection.count()
+        lp.db.collection.count_documents()
 
     def test_authsource_infered_from_db_name(self):
         """The default behavior is to authenticate against the db that the user
@@ -70,7 +70,7 @@ class AuthenticationTest(unittest.TestCase):
         """
         lp = LaunchPad(name="not_the_admin_db", username="myuser",
                        password="mypassword")
-        lp.db.collection.count()
+        lp.db.collection.count_documents()
 
 
 class LaunchPadTest(unittest.TestCase):
@@ -122,7 +122,7 @@ class LaunchPadTest(unittest.TestCase):
         wf = Workflow([fw], name='test_workflow')
         self.lp.add_wf(wf)
         self.assertRaises(ValueError, self.lp.reset, '', False, 0)
-        self.assertEqual(self.lp.workflows.count(), 1)
+        self.assertEqual(self.lp.workflows.count_documents(), 1)
         self.lp.reset('',require_password=False)
         self.assertFalse(self.lp.get_fw_ids())
         self.assertFalse(self.lp.get_wf_ids())

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -54,7 +54,7 @@ class AuthenticationTest(unittest.TestCase):
         with self.assertRaises(OperationFailure):
             lp = LaunchPad(name="admin", username="myuser",
                            password="mypassword", authsource="admin")
-            lp.db.collection.count_documents()
+            lp.db.collection.count_documents({})
 
     def test_authenticating_to_users_db(self):
         """A user should be able to authenticate against a database that they
@@ -62,7 +62,7 @@ class AuthenticationTest(unittest.TestCase):
         """
         lp = LaunchPad(name="not_the_admin_db", username="myuser",
                        password="mypassword", authsource="not_the_admin_db")
-        lp.db.collection.count_documents()
+        lp.db.collection.count_documents({})
 
     def test_authsource_infered_from_db_name(self):
         """The default behavior is to authenticate against the db that the user
@@ -70,7 +70,7 @@ class AuthenticationTest(unittest.TestCase):
         """
         lp = LaunchPad(name="not_the_admin_db", username="myuser",
                        password="mypassword")
-        lp.db.collection.count_documents()
+        lp.db.collection.count_documents({})
 
 
 class LaunchPadTest(unittest.TestCase):
@@ -122,7 +122,7 @@ class LaunchPadTest(unittest.TestCase):
         wf = Workflow([fw], name='test_workflow')
         self.lp.add_wf(wf)
         self.assertRaises(ValueError, self.lp.reset, '', False, 0)
-        self.assertEqual(self.lp.workflows.count_documents(), 1)
+        self.assertEqual(self.lp.workflows.count_documents({}), 1)
         self.lp.reset('',require_password=False)
         self.assertFalse(self.lp.get_fw_ids())
         self.assertFalse(self.lp.get_wf_ids())

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -173,7 +173,7 @@ def reset(args):
     lp = get_lp(args)
     if not args.password:
         if input('Are you sure? This will RESET {} workflows and all data. (Y/N)'.format(
-                lp.workflows.count()))[0].upper() == 'Y':
+                lp.workflows.count_documents()))[0].upper() == 'Y':
             args.password = datetime.datetime.now().strftime('%Y-%m-%d')
         else:
             raise ValueError('Operation aborted by user.')

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -173,7 +173,7 @@ def reset(args):
     lp = get_lp(args)
     if not args.password:
         if input('Are you sure? This will RESET {} workflows and all data. (Y/N)'.format(
-                lp.workflows.count_documents()))[0].upper() == 'Y':
+                lp.workflows.count_documents({})))[0].upper() == 'Y':
             args.password = datetime.datetime.now().strftime('%Y-%m-%d')
         else:
             raise ValueError('Operation aborted by user.')

--- a/fireworks/tests/mongo_tests.py
+++ b/fireworks/tests/mongo_tests.py
@@ -496,23 +496,23 @@ class MongoTests(unittest.TestCase):
 
         time.sleep(1)
 
-        if self.lp.launches.count() > 1:
+        if self.lp.launches.count_documents() > 1:
             print("TOO MANY LAUNCHES FOUND!")
             print("--------")
             for d in self.lp.launches.find():
                 print(d)
             print("--------")
-        self.assertEqual(self.lp.launches.count(), 1)
+        self.assertEqual(self.lp.launches.count_documents(), 1)
 
     def test_append_wf(self):
         fw1 = Firework([UpdateSpecTask()])
         fw2 = Firework([ModSpecTask()])
         self.lp.add_wf(Workflow([fw1, fw2]))
-        self.assertEqual(self.lp.fireworks.count(), 2)
+        self.assertEqual(self.lp.fireworks.count_documents(), 2)
         launch_rocket(self.lp, self.fworker)
         launch_rocket(self.lp, self.fworker)
-        self.assertEqual(self.lp.launches.count(), 2)
-        self.assertEqual(self.lp.fireworks.count(), 3)  # due to detour
+        self.assertEqual(self.lp.launches.count_documents(), 2)
+        self.assertEqual(self.lp.fireworks.count_documents(), 3)  # due to detour
 
         new_wf = Workflow([Firework([ModSpecTask()])])
         self.lp.append_wf(new_wf, [1, 2])
@@ -523,8 +523,8 @@ class MongoTests(unittest.TestCase):
         self.assertEqual(new_fw.spec['dummy1'], 1)
         self.assertEqual(new_fw.spec['dummy2'], [True])
 
-        self.assertEqual(self.lp.launches.count(), 4)
-        self.assertEqual(self.lp.fireworks.count(), 4)
+        self.assertEqual(self.lp.launches.count_documents(), 4)
+        self.assertEqual(self.lp.fireworks.count_documents(), 4)
 
         new_wf = Workflow([Firework([ModSpecTask()])])
         self.lp.append_wf(new_wf, [4])

--- a/fireworks/tests/mongo_tests.py
+++ b/fireworks/tests/mongo_tests.py
@@ -496,23 +496,23 @@ class MongoTests(unittest.TestCase):
 
         time.sleep(1)
 
-        if self.lp.launches.count_documents() > 1:
+        if self.lp.launches.count_documents({}) > 1:
             print("TOO MANY LAUNCHES FOUND!")
             print("--------")
             for d in self.lp.launches.find():
                 print(d)
             print("--------")
-        self.assertEqual(self.lp.launches.count_documents(), 1)
+        self.assertEqual(self.lp.launches.count_documents({}), 1)
 
     def test_append_wf(self):
         fw1 = Firework([UpdateSpecTask()])
         fw2 = Firework([ModSpecTask()])
         self.lp.add_wf(Workflow([fw1, fw2]))
-        self.assertEqual(self.lp.fireworks.count_documents(), 2)
+        self.assertEqual(self.lp.fireworks.count_documents({}), 2)
         launch_rocket(self.lp, self.fworker)
         launch_rocket(self.lp, self.fworker)
-        self.assertEqual(self.lp.launches.count_documents(), 2)
-        self.assertEqual(self.lp.fireworks.count_documents(), 3)  # due to detour
+        self.assertEqual(self.lp.launches.count_documents({}), 2)
+        self.assertEqual(self.lp.fireworks.count_documents({}), 3)  # due to detour
 
         new_wf = Workflow([Firework([ModSpecTask()])])
         self.lp.append_wf(new_wf, [1, 2])
@@ -523,8 +523,8 @@ class MongoTests(unittest.TestCase):
         self.assertEqual(new_fw.spec['dummy1'], 1)
         self.assertEqual(new_fw.spec['dummy2'], [True])
 
-        self.assertEqual(self.lp.launches.count_documents(), 4)
-        self.assertEqual(self.lp.fireworks.count_documents(), 4)
+        self.assertEqual(self.lp.launches.count_documents({}), 4)
+        self.assertEqual(self.lp.fireworks.count_documents({}), 4)
 
         new_wf = Workflow([Firework([ModSpecTask()])])
         self.lp.append_wf(new_wf, [4])

--- a/fireworks/utilities/tests/test_update_collection.py
+++ b/fireworks/utilities/tests/test_update_collection.py
@@ -31,7 +31,7 @@ class UpdateCollectionTests(unittest.TestCase):
         cls.lp.db.test_coll.insert({"foo": "bar", "foo_list": [{"foo1": "bar1"}, {"foo2": "foo/old/path/bar"}]})
         update_path_in_collection(cls.lp.db, collection_name="test_coll", replacements={"old/path": "new/path"},
                                               query=None, dry_run=False, force_clear=False)
-        ndocs = cls.lp.db.test_coll.count_documents()
+        ndocs = cls.lp.db.test_coll.count_documents({})
         cls.assertEqual(ndocs, 1)
         test_doc = cls.lp.db.test_coll.find_one({"foo": "bar"})
         cls.assertEqual(test_doc["foo_list"][1]["foo2"], "foo/new/path/bar")

--- a/fireworks/utilities/tests/test_update_collection.py
+++ b/fireworks/utilities/tests/test_update_collection.py
@@ -31,7 +31,7 @@ class UpdateCollectionTests(unittest.TestCase):
         cls.lp.db.test_coll.insert({"foo": "bar", "foo_list": [{"foo1": "bar1"}, {"foo2": "foo/old/path/bar"}]})
         update_path_in_collection(cls.lp.db, collection_name="test_coll", replacements={"old/path": "new/path"},
                                               query=None, dry_run=False, force_clear=False)
-        ndocs = cls.lp.db.test_coll.count()
+        ndocs = cls.lp.db.test_coll.count_documents()
         cls.assertEqual(ndocs, 1)
         test_doc = cls.lp.db.test_coll.find_one({"foo": "bar"})
         cls.assertEqual(test_doc["foo_list"][1]["foo2"], "foo/new/path/bar")

--- a/fireworks/utilities/update_collection.py
+++ b/fireworks/utilities/update_collection.py
@@ -68,7 +68,7 @@ def update_path_in_collection(db, collection_name, replacements, query=None, dry
 
         modified_docs.append(doc["_id"])
 
-    ndocs = db[collection_name].find({"_id": {"$nin": modified_docs}}).count_documents({})
+    ndocs = db[collection_name].count_documents({"_id": {"$nin": modified_docs}})
     all_docs = db[collection_name].find({"_id": {"$nin": modified_docs}})
 
     print("transferring unaffected documents (if any)")
@@ -77,7 +77,7 @@ def update_path_in_collection(db, collection_name, replacements, query=None, dry
         modified_docs.append(doc["_id"])
 
     print("confirming that all documents were moved")
-    ndocs = db[collection_name].find({"_id": {"$nin": modified_docs}}).count_documents({})
+    ndocs = db[collection_name].count_documents({"_id": {"$nin": modified_docs}})
     if ndocs != 0:
         raise ValueError("update paths aborted! Are you sure new documents are not being inserted into the collection?")
 

--- a/fireworks/utilities/update_collection.py
+++ b/fireworks/utilities/update_collection.py
@@ -54,7 +54,7 @@ def update_path_in_collection(db, collection_name, replacements, query=None, dry
                              format(collection_name, extension_name))
 
     all_docs = db[collection_name].find(query)
-    ndocs = db[collection_name].find(query).count_documents({})
+    ndocs = db[collection_name].count_documents(query or {})
 
     modified_docs = []  # all docs that were modified; needed if you set "query" parameter
     print("updating new documents:")

--- a/fireworks/utilities/update_collection.py
+++ b/fireworks/utilities/update_collection.py
@@ -54,7 +54,7 @@ def update_path_in_collection(db, collection_name, replacements, query=None, dry
                              format(collection_name, extension_name))
 
     all_docs = db[collection_name].find(query)
-    ndocs = db[collection_name].find(query).count()
+    ndocs = db[collection_name].find(query).count_documents()
 
     modified_docs = []  # all docs that were modified; needed if you set "query" parameter
     print("updating new documents:")
@@ -68,7 +68,7 @@ def update_path_in_collection(db, collection_name, replacements, query=None, dry
 
         modified_docs.append(doc["_id"])
 
-    ndocs = db[collection_name].find({"_id": {"$nin": modified_docs}}).count()
+    ndocs = db[collection_name].find({"_id": {"$nin": modified_docs}}).count_documents()
     all_docs = db[collection_name].find({"_id": {"$nin": modified_docs}})
 
     print("transferring unaffected documents (if any)")
@@ -77,7 +77,7 @@ def update_path_in_collection(db, collection_name, replacements, query=None, dry
         modified_docs.append(doc["_id"])
 
     print("confirming that all documents were moved")
-    ndocs = db[collection_name].find({"_id": {"$nin": modified_docs}}).count()
+    ndocs = db[collection_name].find({"_id": {"$nin": modified_docs}}).count_documents()
     if ndocs != 0:
         raise ValueError("update paths aborted! Are you sure new documents are not being inserted into the collection?")
 

--- a/fireworks/utilities/update_collection.py
+++ b/fireworks/utilities/update_collection.py
@@ -54,7 +54,7 @@ def update_path_in_collection(db, collection_name, replacements, query=None, dry
                              format(collection_name, extension_name))
 
     all_docs = db[collection_name].find(query)
-    ndocs = db[collection_name].find(query).count_documents()
+    ndocs = db[collection_name].find(query).count_documents({})
 
     modified_docs = []  # all docs that were modified; needed if you set "query" parameter
     print("updating new documents:")
@@ -68,7 +68,7 @@ def update_path_in_collection(db, collection_name, replacements, query=None, dry
 
         modified_docs.append(doc["_id"])
 
-    ndocs = db[collection_name].find({"_id": {"$nin": modified_docs}}).count_documents()
+    ndocs = db[collection_name].find({"_id": {"$nin": modified_docs}}).count_documents({})
     all_docs = db[collection_name].find({"_id": {"$nin": modified_docs}})
 
     print("transferring unaffected documents (if any)")
@@ -77,7 +77,7 @@ def update_path_in_collection(db, collection_name, replacements, query=None, dry
         modified_docs.append(doc["_id"])
 
     print("confirming that all documents were moved")
-    ndocs = db[collection_name].find({"_id": {"$nin": modified_docs}}).count_documents()
+    ndocs = db[collection_name].find({"_id": {"$nin": modified_docs}}).count_documents({})
     if ndocs != 0:
         raise ValueError("update paths aborted! Are you sure new documents are not being inserted into the collection?")
 


### PR DESCRIPTION
Closes #322.

`count()` was deprecated in pymongo 3.7.2

