### PR TITLE
Some format string fixes and upgrades

### DIFF
--- a/docs/_sources/reference.rst.txt
+++ b/docs/_sources/reference.rst.txt
@@ -65,7 +65,7 @@ _add_launchpad_and_fw_id  Embeds LaunchPad (``launchpad``) and fw_id (``fw_id``)
 _dupefinder               Used to specify a duplicate finder object for avoiding duplicated runs. More information :doc:`here </duplicates_tutorial>`.
 _allow_fizzled_parents    Run this Firework if all parents are *either* COMPLETED or FIZZLED.
 _preserve_fworker         Run the children on the same FireWorker as the parent
-_job_info                 Reserved for automatically putting putting information about previous jobs via the ``_pass_job_info`` option.
+_job_info                 Reserved for automatically putting information about previous jobs via the ``_pass_job_info`` option.
 _fizzled_parents          Reserved for automatically putting information about FIZZLED parents in a child Firework with the ``_allow_fizzled_parents`` option.
 _trackers                 Reserved for specifying Trackers.
 _background_tasks         Reserved for specifying BackgroundTasks

--- a/docs_rst/changelog.rst
+++ b/docs_rst/changelog.rst
@@ -9,7 +9,7 @@ FireWorks Changelog
 * avoid checking the number of jobs in the queue if not needed (G. Petretto)
 * Avoid failures due to encoding issues in tracker (J. Hörmann)
 * Filepad accessible via TLS/SSL encrypted connection (J. Hörmann)
-* llow propagating modified spec not only to direct children, but along all decendants down to workflow leaves by adding a 'propagate' flag to FWAction. (J. Hörmann)
+* allow propagating modified spec not only to direct children, but along all descendants down to workflow leaves by adding a 'propagate' flag to FWAction. (J. Hörmann)
 * update some dependency versions
 * misc fixes and updates (mamachra, J. Hörmann, I. Kondov, A. Jain)
 
@@ -364,7 +364,7 @@ FireWorks Changelog
 * add launches mode query (query launches collection when performing lpad tasks)
 * Add auth option to web app (S.P. Ong)
 * enhance webapp server w/gunicorn (D. Winston)
-* threshold parameter in introspect commmand
+* threshold parameter in introspect command
 * add license option to SLURM adapter
 * add fill mode to qlaunch for keeping jobs in the queue even when nothing in DB to run
 * fix njobs_queue bug

--- a/docs_rst/config_tutorial.rst
+++ b/docs_rst/config_tutorial.rst
@@ -91,6 +91,6 @@ Some parameters that you can change, but probably shouldn't, are:
 * ``RESERVATION_EXPIRATION_SECS: 1209600`` - means that the LaunchPad will cancel the reservation of a Firework that's been in the queue for 1209600 seconds (14 days). See the :doc:`queue reservation tutorial <queue_tutorial_pt2>`.
 * ``FW_BLOCK_FORMAT: %Y-%m-%d-%H-%M-%S-%f`` - the ``launcher_`` and ``block_`` directories written by the Rocket and Queue Launchers add a date stamp to the directory. You can change this if desired.
 * ``QSTAT_FREQUENCY: 50`` - number of jobs submitted to queue before re-executing a qstat. 1 means always do qstat, higher avoids unnecessarily loading the qstat server. Set this low if you have multiple processes submitting jobs to the same queue.
-* ``PW_CHECK_NUM: 10`` - how many FireWorks/Worflows can be changed with a single LaunchPad command (like ``rerun_fws``) before a password is required.
+* ``PW_CHECK_NUM: 10`` - how many FireWorks/Workflows can be changed with a single LaunchPad command (like ``rerun_fws``) before a password is required.
 
 For a full list of parameters that can be changed, you can browse the ``fw_config.py`` file in the FireWorks source.

--- a/docs_rst/contributing.rst
+++ b/docs_rst/contributing.rst
@@ -37,7 +37,7 @@ Documentation, coding style, and tests
 
 We ask for reasonably clear documentation of modules, classes, methods, and tricky code sections (hopefully not too many of the last item!) Where possible, code within a method or class should be easy to understand without the need for additional documentation. In some cases, we may request a tutorial to clarify usage of your code to the community. In terms of programming style, some guidelines are given in `PEP 8 <http://www.python.org/dev/peps/pep-0008/>`_, but we mainly ask that you try to follow the style of the FireWorks core modules. Depending on the complexity of the contribution, tests might need to be included along with your code.
 
-However, when starting you should not be as concerned with these issues as with writing clear, succint, and functional code. If we feel that issues such as documentation or style are preventing merging of your code with the main repo, a core developer may request your permission to re-document and/or re-style your code, and add his/her name to either the ``__credits__`` or ``__authors__`` field of your code header (your name will still be retained in the ``__authors__`` field).
+However, when starting you should not be as concerned with these issues as with writing clear, succinct, and functional code. If we feel that issues such as documentation or style are preventing merging of your code with the main repo, a core developer may request your permission to re-document and/or re-style your code, and add his/her name to either the ``__credits__`` or ``__authors__`` field of your code header (your name will still be retained in the ``__authors__`` field).
 
 OS Compatibility
 ----------------

--- a/docs_rst/filepad_tutorial.rst
+++ b/docs_rst/filepad_tutorial.rst
@@ -3,7 +3,7 @@ Using FilePad for storing and retrieving files
 ===============================================
 
 
-FilePad utility provides the api to add and delete arbitrary files of arbitray sizes to MongoDB(filepad).
+FilePad utility provides the api to add and delete arbitrary files of arbitrary sizes to MongoDB(filepad).
 The is achieved by inserting the entire file contents to GridFS and storing the id returned by the
 GridFS insertion, the user provided identifier and the metadata in a document in the filepad. In the following
 documentation, ``file contents`` refers to the file contents stored in GridFS and ``document`` refers to the

--- a/docs_rst/installation.rst
+++ b/docs_rst/installation.rst
@@ -16,7 +16,7 @@ To access via a *cloud provider*, you might try `mLab <http://mlab.com/>`_, `Mon
     * Set up an account via the mLab web site instructions. When asked to pick a server type (e.g. Amazon, Google, etc) you can just choose free option of 500MB. This is more than enough to get started.
     * mLab will ask you to create a database; any name is fine, but make sure you write down what it is.
     * After creating a database, note that you'll need to create at least one database user in order to access the database.
-    * You can test your database connection using MongoDB's built-in command line tools. Or, you can continue with FireWorks installation and subsequently the tutorials, which will test the database connnection as part of the procedure.
+    * You can test your database connection using MongoDB's built-in command line tools. Or, you can continue with FireWorks installation and subsequently the tutorials, which will test the database connection as part of the procedure.
 
 Preparing to Install FireWorks (Python and pip)
 ===============================================

--- a/docs_rst/maintain_tutorial.rst
+++ b/docs_rst/maintain_tutorial.rst
@@ -2,7 +2,7 @@
 Database administration commands
 ================================
 
-There are two types of maintainence operations that can be performed through the LaunchPad:
+There are two types of maintenance operations that can be performed through the LaunchPad:
 
 * **maintain** - automatically detects and marks failed jobs and deleted queue reservations
 * **tuneup** - tries to speed up database performance by updating indices and compacting the database. Should be performed during database downtime.

--- a/docs_rst/queue_tutorial.rst
+++ b/docs_rst/queue_tutorial.rst
@@ -222,7 +222,7 @@ Limitations
 To keep the code simple, qlaunch default remote options are limited to
 similar configurations across multiple resources. If you have more
 complicated setups, e.g., different users, different queue configurations
-across different computing resoruces, remote qlaunch will not be able to
+across different computing resources, remote qlaunch will not be able to
 handle these. However, you can always write your own fabfile.py and use
 Fabric's far more sophisticated execution model.
 

--- a/docs_rst/reference.rst
+++ b/docs_rst/reference.rst
@@ -65,11 +65,11 @@ _add_launchpad_and_fw_id  Embeds LaunchPad (``launchpad``) and fw_id (``fw_id``)
 _dupefinder               Used to specify a duplicate finder object for avoiding duplicated runs. More information :doc:`here </duplicates_tutorial>`.
 _allow_fizzled_parents    Run this Firework if all parents are *either* COMPLETED or FIZZLED.
 _preserve_fworker         Run the children on the same FireWorker as the parent
-_job_info                 Reserved for automatically putting putting information about previous jobs via the ``_pass_job_info`` option.
+_job_info                 Reserved for automatically putting information about previous jobs via the ``_pass_job_info`` option.
 _fizzled_parents          Reserved for automatically putting information about FIZZLED parents in a child Firework with the ``_allow_fizzled_parents`` option.
 _trackers                 Reserved for specifying Trackers.
 _background_tasks         Reserved for specifying BackgroundTasks
-_fw_env                   Reserved for setting worker-specifc environment variables. More information :doc:`here </worker_tutorial>`.
+_fw_env                   Reserved for setting worker-specific environment variables. More information :doc:`here </worker_tutorial>`.
 _files_in                 Reserved for specifying a dict of {name: filename} for input files to be copied from preceding FW.
 _files_out                Reserved for specifying a dict of {name, output file name} that can be copied by a child FW.
 _files_prev               Reserved for storing the actual full filepaths if _files_out is specified.

--- a/docs_rst/rerun_tutorial.rst
+++ b/docs_rst/rerun_tutorial.rst
@@ -5,7 +5,7 @@ Rerunning a Firework or Workflow
 In some instances, you may want to rerun a Firework or Workflow. For example, your computing resource may have crashed or been configured incorrectly during the first run, leading to your first launch being *FIZZLED*. When you rerun a Firework:
 
 * All the Firework's previous launches are *archived* into a special section of the Firework called *archived_launches*. This process also occurs for all the children of the Firework (but not the parents).
-* The Firework's state is reset back *READY*. The state of all children is reset back to *WAITING* for the Firework to complete. The archived launches can be read by the user but do not affect the operation of the Firework.
+* The Firework's state is reset back to *READY*. The state of all children is reset back to *WAITING* for the Firework to complete. The archived launches can be read by the user but do not affect the operation of the Firework.
 
 One issue with rerunning FireWorks is that the procedure does not reset any previous actions taken by your Firework. For example, if your Firework executed an instruction to create a new Workflow step within its FWAction, or modified the inputs of the child Firework, these actions will **not** be reset when you rerun the Firework. The point is important enough that we'll repeat it in a warning:
 
@@ -40,7 +40,7 @@ A Firework might fail while running one of its intermediate or final Firetasks. 
 
     lpad rerun_fws -s FIZZLED  --task-level
 
-Further options exist, e.g. to attempt to copy data from the previous run into the new run attempt (same filesystem only) via ``--copy-data`` or attempt to rerun in the same directory (``--previous-dir``). Refer to the documentation (``lpad rerun_fws -h``) for more information.  Note also that task-level reruns will modify the spec of your firework such that future standard (i. e. non-task-level) reruns will retain the recovery and attempt to restart at the task level using that recovery.  If you want to clear the recovery information from the spec to ensure that fireworks starts from scratch, you can do so by using the ``--clear-recovery`` flag, e. g. ``lpad rerun_fws -i <FW_IDS> --clear-recovery``.
+Further options exist, e.g. to attempt to copy data from the previous run into the new run attempt (same filesystem only) via ``--copy-data`` or attempt to rerun in the same directory (``--previous-dir``). Refer to the documentation (``lpad rerun_fws -h``) for more information.  Note also that task-level reruns will modify the spec of your firework such that future standard (i.e. non-task-level) reruns will retain the recovery and attempt to restart at the task level using that recovery.  If you want to clear the recovery information from the spec to ensure that fireworks starts from scratch, you can do so by using the ``--clear-recovery`` flag, e.g. ``lpad rerun_fws -i <FW_IDS> --clear-recovery``.
 
 Rerunning based on error message
 ================================

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -78,9 +78,8 @@ class FiretaskBase(defaultdict, FWSerializable, metaclass=abc.ABCMeta):
             for k in kwargs:
                 if k not in allowed_params:
                     raise RuntimeError(
-                        "Invalid keyword argument specified for: {}. You specified: {}. Allowed values are: {}.".format(
-                            self.__class__, k, allowed_params
-                        )
+                        f"Invalid keyword argument specified for: {self.__class__}. "
+                        f"You specified: {k}. Allowed values are: {allowed_params}."
                     )
 
     @abc.abstractmethod
@@ -815,8 +814,8 @@ class Workflow(FWSerializable):
             for pfw in fw.parents:
                 if pfw.fw_id not in self.links:
                     raise ValueError(
-                        "FW_id: {} defines a dependent link to FW_id: {}, but the latter was not "
-                        "added to the workflow!".format(fw.fw_id, pfw.fw_id)
+                        f"FW_id: {fw.fw_id} defines a dependent link to FW_id: {pfw.fw_id}, but the latter was not "
+                        "added to the workflow!"
                     )
                 if fw.fw_id not in self.links[pfw.fw_id]:
                     self.links[pfw.fw_id].append(fw.fw_id)
@@ -1037,9 +1036,8 @@ class Workflow(FWSerializable):
                     ready_run = [(f >= 0 and Firework.STATE_RANKS[self.fw_states[f]] > 1) for f in self.links[fw_id]]
                     if any(ready_run):
                         raise ValueError(
-                            "fw_id: {}: Detour option only works if all children "
-                            "of detours are not READY to run and have not "
-                            "already run".format(fw_id)
+                            f"fw_id: {fw_id}: Detour option only works if all children "
+                            "of detours are not READY to run and have not already run"
                         )
 
         # make sure all new child fws have negative fw_id

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -33,11 +33,7 @@ from fireworks.utilities.fw_serializers import (
     recursive_serialize,
     serialize_fw,
 )
-from fireworks.utilities.fw_utilities import (
-    NestedClassGetter,
-    get_my_host,
-    get_my_ip,
-)
+from fireworks.utilities.fw_utilities import NestedClassGetter, get_my_host, get_my_ip
 
 __author__ = "Anubhav Jain"
 __credits__ = "Shyue Ping Ong"
@@ -986,7 +982,7 @@ class Workflow(FWSerializable):
         Archives the launches of a Firework so that it can be re-run.
 
         Args:
-            fw_id (int): id of firework to tbe rerun
+            fw_id (int): id of firework to rerun
             updated_ids (set(int)): set of fireworks id to rerun
 
         Returns:

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -978,7 +978,7 @@ class LaunchPad(FWSerializable):
 
         self.m_logger.debug("Updating indices...")
         self.fireworks.create_index("fw_id", unique=True, background=bkground)
-        for f in ("state", "spec._category", "created_on", "updated_on" "name", "launches"):
+        for f in ("state", "spec._category", "created_on", "updated_on", "name", "launches"):
             self.fireworks.create_index(f, background=bkground)
 
         self.launches.create_index("launch_id", unique=True, background=bkground)

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -308,8 +308,7 @@ class LaunchPad(FWSerializable):
             {"fw_id": {"$in": fw_ids}, "state": {"$nin": allowed_states}}, {"fw_id": 1, "state": 1}
         ):
             self.m_logger.warning(
-                "Cannot update spec of fw_id: {} with state: {}. "
-                "Try rerunning first".format(fw["fw_id"], fw["state"])
+                f"Cannot update spec of fw_id: {fw['fw_id']} with state: {fw['state']}. Try rerunning first."
             )
 
     @classmethod
@@ -388,10 +387,8 @@ class LaunchPad(FWSerializable):
             self.m_logger.info("LaunchPad was RESET.")
         elif not require_password:
             raise ValueError(
-                "Password check cannot be overridden since the size of DB ({} workflows) "
-                "is greater than the max_reset_wo_password parameter ({}).".format(
-                    self.fireworks.count_documents({}), max_reset_wo_password
-                )
+                f"Password check cannot be overridden since the size of DB ({self.fireworks.count_documents({})} "
+                f"workflows) is greater than the max_reset_wo_password parameter ({max_reset_wo_password})."
             )
         else:
             raise ValueError(f"Invalid password! Password is today's date: {m_password}")
@@ -1754,7 +1751,7 @@ class LaunchPad(FWSerializable):
 
         # rerun this FW
         if m_fw["state"] in ["ARCHIVED", "DEFUSED"]:
-            self.m_logger.info("Cannot rerun fw_id: {}: it is {}.".format(fw_id, m_fw["state"]))
+            self.m_logger.info(f"Cannot rerun fw_id: {fw_id}: it is {m_fw['state']}.")
         elif m_fw["state"] == "WAITING" and not recover_launch:
             self.m_logger.debug(f"Skipping rerun fw_id: {fw_id}: it is already WAITING.")
         else:
@@ -1862,9 +1859,7 @@ class LaunchPad(FWSerializable):
             self.m_logger.debug(f"Querying for duplicates, fw_id: {thief_fw.fw_id}")
             # iterate through all potential duplicates in the DB
             for potential_match in self.fireworks.find(m_query):
-                self.m_logger.debug(
-                    "Verifying for duplicates, fw_ids: {}, {}".format(thief_fw.fw_id, potential_match["fw_id"])
-                )
+                self.m_logger.debug(f"Verifying for duplicates, fw_ids: {thief_fw.fw_id}, {potential_match['fw_id']}")
 
                 # see if verification is needed, as this slows the process
                 verified = False
@@ -1893,9 +1888,7 @@ class LaunchPad(FWSerializable):
                     for launch in valuable_launches:
                         thief_fw.launches.append(launch)
                         stolen = True
-                        self.m_logger.info(
-                            "Duplicate found! fwids {} and {}".format(thief_fw.fw_id, potential_match["fw_id"])
-                        )
+                        self.m_logger.info(f"Duplicate found! fwids {thief_fw.fw_id} and {potential_match['fw_id']}")
         return stolen
 
     def set_priority(self, fw_id, priority):
@@ -1974,8 +1967,8 @@ class LaunchPad(FWSerializable):
                     self.ping_launch(launch_id, ptime=ping_dict["ping_time"], checkpoint=checkpoint)
                 else:
                     warnings.warn(
-                        "Unable to find FW_ping.json in {}! State history updated_on might be incorrect, trackers "
-                        "may not update.".format(m_launch.launch_dir)
+                        f"Unable to find FW_ping.json in {m_launch.launch_dir}! State history updated_on might be "
+                        "incorrect, trackers may not update."
                     )
                     m_launch.touch_history(checkpoint=checkpoint)
 

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -23,13 +23,7 @@ from pymongo import ASCENDING, DESCENDING, MongoClient
 from pymongo.errors import DocumentTooLarge
 from tqdm import tqdm
 
-from fireworks.core.firework import (
-    Firework,
-    FWAction,
-    Launch,
-    Tracker,
-    Workflow,
-)
+from fireworks.core.firework import Firework, FWAction, Launch, Tracker, Workflow
 from fireworks.fw_config import (
     GRIDFS_FALLBACK_COLLECTION,
     LAUNCHPAD_LOC,
@@ -102,7 +96,7 @@ class LockedWorkflowError(ValueError):
 class WFLock:
     """
     Lock a Workflow, i.e. for performing update operations
-    Raises a LockedWorkflowError if the lock couldn't be acquired withing expire_secs and kill==False.
+    Raises a LockedWorkflowError if the lock couldn't be acquired within expire_secs and kill==False.
     Calling functions are responsible for handling the error in order to avoid database inconsistencies.
     """
 

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -1598,7 +1598,7 @@ class LaunchPad(FWSerializable):
                 json.dumps(action_dict), encoding="utf-8", metadata={"launch_id": launch_id}
             )
             launch_db_dict["action"] = {"gridfs_id": str(action_id)}
-            self.m_logger.warning("The size of the launch document was too large. Saving " "the action in gridfs.")
+            self.m_logger.warning("The size of the launch document was too large. Saving the action in gridfs.")
 
             self.launches.find_one_and_replace({"launch_id": m_launch.launch_id}, launch_db_dict, upsert=True)
 

--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -373,9 +373,8 @@ class Rocket:
             l_logger.log(logging.DEBUG, traceback.format_exc())
             l_logger.log(
                 logging.WARNING,
-                "Firework {} reached final state {} but couldn't complete the update of "
-                "the database. Reason: {}\nRefresh the WF to recover the result "
-                "(lpad admin refresh -i {}).".format(self.fw_id, final_state, e, self.fw_id),
+                f"Firework {self.fw_id} reached final state {final_state} but couldn't complete the database update. "
+                f"Reason: {e}\nRefresh the WF to recover the result (lpad admin refresh -i {self.fw_id}).",
             )
             return True
 

--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -410,9 +410,8 @@ class Rocket:
                     l_logger.log(logging.DEBUG, traceback.format_exc())
                     l_logger.log(
                         logging.WARNING,
-                        "Firework {} fizzled but couldn't complete the update of the database."
-                        " Reason: {}\nRefresh the WF to recover the result "
-                        "(lpad admin refresh -i {}).".format(self.fw_id, final_state, e, self.fw_id),
+                        f"Firework {self.fw_id} fizzled but couldn't complete the update of the database. "
+                        f"Reason: {e}\nRefresh the WF to recover the result (lpad admin refresh -i {self.fw_id}).",
                     )
                     return True
             else:

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -36,7 +36,7 @@ MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class AuthenticationTest(unittest.TestCase):
-    """Tests whether users are authenticating agains the correct mongo dbs."""
+    """Tests whether users are authenticating against the correct mongo dbs."""
 
     @classmethod
     def setUpClass(cls):
@@ -108,7 +108,7 @@ class LaunchPadTest(unittest.TestCase):
 
     def test_reset(self):
         # Store some test fireworks
-        # Atempt couple of ways to reset the lp and check
+        # Attempt couple of ways to reset the lp and check
         fw = Firework(ScriptTask.from_str('echo "hello"'), name="hello")
         wf = Workflow([fw], name="test_workflow")
         self.lp.add_wf(wf)

--- a/fireworks/examples/custom_firetasks/merge_task/merge_task.py
+++ b/fireworks/examples/custom_firetasks/merge_task/merge_task.py
@@ -33,8 +33,8 @@ class TaskB(FiretaskBase):
 class TaskC(FiretaskBase):
     def run_task(self, fw_spec):
         print("This is task C.")
-        print("Task A gave me: {}".format(fw_spec["param_A"]))
-        print("Task B gave me: {}".format(fw_spec["param_B"]))
+        print(f"Task A gave me: {fw_spec['param_A']}")
+        print(f"Task B gave me: {fw_spec['param_B']}")
 
 
 if __name__ == "__main__":

--- a/fireworks/features/fw_report.py
+++ b/fireworks/features/fw_report.py
@@ -206,9 +206,9 @@ class FWReport:
             border_str = "=" * len(header_str) + "\n"
             my_str += border_str
 
-            for i in x["states"]:
-                my_str += f"{i} : {x['states'][i]}\n"
+            for state in x["states"]:
+                my_str += f"{state} : {x['states'][state]}\n"
 
             my_str += f"\ntotal : {x['count']}\n"
-            my_str += f"C/(C+F) : {x['completed_score']}%\n\n"
+            my_str += f"C/(C+F) : {x['completed_score']:.1f}%\n\n"
         return my_str

--- a/fireworks/features/introspect.py
+++ b/fireworks/features/introspect.py
@@ -128,7 +128,7 @@ class Introspector:
             nsamples_fizzled += 1
             if state_key == "spec._tasks":
                 for t in doc["spec"]["_tasks"]:
-                    fizzled_keys.append("_fw_name{}{}".format(separator_str, t["_fw_name"]))
+                    fizzled_keys.append(f"_fw_name{separator_str}{t['_fw_name']}")
             elif state_key == "action.stored_data._exception._stacktrace":
                 stacktrace = (
                     doc.get("action", {})
@@ -151,7 +151,7 @@ class Introspector:
                 nsamples_completed += 1
                 if state_key == "spec._tasks":
                     for t in doc["spec"]["_tasks"]:
-                        completed_keys.append("_fw_name{}{}".format(separator_str, t["_fw_name"]))
+                        completed_keys.append(f"_fw_name{separator_str}{t['_fw_name']}")
                 else:
                     completed_keys.extend(flatten_to_keys(doc[state_key]))
 

--- a/fireworks/flask_site/app.py
+++ b/fireworks/flask_site/app.py
@@ -55,7 +55,7 @@ def check_auth(username, password):
 def authenticate():
     """Sends a 401 response that enables basic auth"""
     return Response(
-        "Could not verify your access level for that URL. You have to login " "with proper credentials",
+        "Could not verify your access level for that URL. You have to login with proper credentials",
         401,
         {"WWW-Authenticate": 'Basic realm="Login Required"'},
     )

--- a/fireworks/flask_site/app.py
+++ b/fireworks/flask_site/app.py
@@ -369,10 +369,8 @@ def parse_querystr(querystr, coll):
         return {}
     if WEBSERVER_PERFWARNINGS and not fwapp_util.uses_index(d, coll):
         flash(
-            "`{}` does not use a mongo index. "
-            "If you expect to use this query often, add an index "
-            "to the database collection "
-            "to make it run faster.".format(querystr)
+            f"`{querystr}` does not use a mongo index. If you expect to use this query often, "
+            "add an index to the database collection to make it run faster."
         )
     return d
 

--- a/fireworks/flask_site/gunicorn.py
+++ b/fireworks/flask_site/gunicorn.py
@@ -28,7 +28,7 @@ class StandaloneApplication(gunicorn.app.base.BaseApplication):
 
 if __name__ == "__main__":
     options = {
-        "bind": "{}:{}".format("127.0.0.1", "8080"),
+        "bind": "127.0.0.1:8080",
         "workers": number_of_workers(),
     }
     StandaloneApplication(handler_app, options).run()

--- a/fireworks/fw_config.py
+++ b/fireworks/fw_config.py
@@ -66,7 +66,7 @@ CONFIG_FILE_DIR = "."  # directory containing config files (if not individually 
 
 ROCKET_STREAM_LOGLEVEL = "INFO"  # the streaming log level of the rocket.launcher logger
 
-QSTAT_FREQUENCY = 50  # set this higher to avoid qstats, lower to alwas
+QSTAT_FREQUENCY = 50  # set this higher to avoid qstats, lower to always
 
 ALWAYS_CREATE_NEW_BLOCK = False  # always create new block on queue launcher call
 

--- a/fireworks/fw_config.py
+++ b/fireworks/fw_config.py
@@ -124,11 +124,7 @@ def override_user_settings():
     config_paths = config_paths or [os.path.join(os.path.expanduser("~"), ".fireworks", "FW_config.yaml")]
 
     if len(config_paths) > 1:
-        print(
-            "Found many potential paths for {}: {}\nChoosing as default: {}".format(
-                "FW_CONFIG_FILE", config_paths, config_paths[0]
-            )
-        )
+        print(f"Found many potential paths for FW_CONFIG_FILE: {config_paths}\nChoosing as default: {config_paths[0]}")
 
     if os.path.exists(config_paths[0]):
         overrides = loadfn(config_paths[0])
@@ -144,7 +140,7 @@ def override_user_settings():
 
     for k in ["LAUNCHPAD_LOC", "FWORKER_LOC", "QUEUEADAPTER_LOC"]:
         if globals().get(k, None) is None:
-            fname = "my_qadapter.yaml" if k == "QUEUEADAPTER_LOC" else "my_{}.yaml".format(k.split("_")[0].lower())
+            fname = "my_qadapter.yaml" if k == "QUEUEADAPTER_LOC" else f"my_{k.split('_')[0].lower()}.yaml"
             m_paths = []
             if os.path.realpath(CONFIG_FILE_DIR) not in test_paths:
                 test_paths.insert(0, CONFIG_FILE_DIR)

--- a/fireworks/queue/queue_adapter.py
+++ b/fireworks/queue/queue_adapter.py
@@ -134,9 +134,8 @@ class QueueAdapterBase(collections.defaultdict, FWSerializable):
             for subs_key in subs_dict.keys():
                 if subs_key not in template_keys and not subs_key.startswith("_") and not subs_key == "logdir":
                     warnings.warn(
-                        "Key {} has been specified in qadapter "
-                        "but it is not present in template, please "
-                        "check template ({}) for supported keys.".format(subs_key, self.template_file)
+                        f"Key {subs_key} has been specified in qadapter but it is not present in template, "
+                        f"please check template ({self.template_file}) for supported keys."
                     )
 
             for k, v in self.defaults.items():

--- a/fireworks/queue/queue_launcher.py
+++ b/fireworks/queue/queue_launcher.py
@@ -77,7 +77,7 @@ def launch_rocket_to_queue(
         raise ValueError(f"Desired launch directory {launcher_dir} does not exist!")
 
     if "--offline" in qadapter["rocket_launch"] and not reserve:
-        raise ValueError("Must use reservation mode (-r option) of qlaunch " "when using offline option of rlaunch!!")
+        raise ValueError("Must use reservation mode (-r option) of qlaunch when using offline option of rlaunch!!")
 
     if reserve and "singleshot" not in qadapter.get("rocket_launch", ""):
         raise ValueError("Reservation mode of queue launcher only works for singleshot Rocket Launcher!")
@@ -149,7 +149,7 @@ def launch_rocket_to_queue(
                 reservation_id = qadapter.submit_to_queue(SUBMIT_SCRIPT_NAME)
                 if not reservation_id:
                     raise RuntimeError(
-                        "queue script could not be submitted, check queue " "script/queue adapter/queue server status!"
+                        "queue script could not be submitted, check queue script/queue adapter/queue server status!"
                     )
                 elif reserve:
                     launchpad.set_reservation_id(launch_id, reservation_id)
@@ -336,7 +336,7 @@ def _get_number_of_jobs_in_queue(qadapter, njobs_queue, l_logger):
         time.sleep(RETRY_INTERVAL)
         RETRY_INTERVAL *= 2
 
-    raise RuntimeError("Unable to determine number of jobs in queue, " "check queue adapter and queue server status!")
+    raise RuntimeError("Unable to determine number of jobs in queue, check queue adapter and queue server status!")
 
 
 def setup_offline_job(launchpad, fw, launch_id):

--- a/fireworks/queue/queue_launcher.py
+++ b/fireworks/queue/queue_launcher.py
@@ -250,9 +250,7 @@ def rapidfire(
                     break
 
                 if njobs_queue and jobs_in_queue >= njobs_queue:
-                    l_logger.info(
-                        "Jobs in queue ({}) meets/exceeds " "maximum allowed ({})".format(jobs_in_queue, njobs_queue)
-                    )
+                    l_logger.info(f"Jobs in queue ({jobs_in_queue}) meets/exceeds maximum allowed ({njobs_queue})")
                     break
 
                 l_logger.info("Launching a rocket!")
@@ -273,7 +271,7 @@ def rapidfire(
                     raise RuntimeError("Launch unsuccessful!")
                 num_launched += 1
                 if nlaunches > 0 and num_launched == nlaunches:
-                    l_logger.info("Launched allowed number of " "jobs: {}".format(num_launched))
+                    l_logger.info(f"Launched allowed number of jobs: {num_launched}")
                     break
                 # wait for the queue system to update
                 l_logger.info(f"Sleeping for {QUEUE_UPDATE_INTERVAL} seconds...zzz...")
@@ -331,12 +329,10 @@ def _get_number_of_jobs_in_queue(qadapter, njobs_queue, l_logger):
         try:
             jobs_in_queue = qadapter.get_njobs_in_queue()
             if jobs_in_queue is not None:
-                l_logger.info("{} jobs in queue. " "Maximum allowed by user: {}".format(jobs_in_queue, njobs_queue))
+                l_logger.info(f"{jobs_in_queue} jobs in queue. Maximum allowed by user: {njobs_queue}")
                 return jobs_in_queue
         except Exception:
-            log_exception(
-                l_logger, "Could not get number of jobs in queue! " "Sleeping {} secs...zzz...".format(RETRY_INTERVAL)
-            )
+            log_exception(l_logger, f"Could not get number of jobs in queue! Sleeping {RETRY_INTERVAL} secs...zzz...")
         time.sleep(RETRY_INTERVAL)
         RETRY_INTERVAL *= 2
 

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -57,8 +57,8 @@ def pw_check(ids, args, skip_pw=False):
                 print("Operation aborted by user.")
         if args.password != m_password:
             raise ValueError(
-                "Modifying more than {} entries requires setting the --password parameter! "
-                "(Today's date, e.g. 2012-02-25)".format(PW_CHECK_NUM)
+                f"Modifying more than {PW_CHECK_NUM} entries requires setting the --password parameter! "
+                "(Today's date, e.g. 2012-02-25)"
             )
     return ids
 
@@ -120,7 +120,7 @@ def get_lp(args):
         traceback.print_exc()
         err_message = (
             "FireWorks was not able to connect to MongoDB. Is the server running? "
-            "The database file specified was {}.".format(args.launchpad_file)
+            f"The database file specified was {args.launchpad_file}."
         )
         if not args.launchpad_file:
             err_message += (
@@ -824,7 +824,7 @@ def track_fws(args):
         for d in data:
             for t in d["trackers"]:
                 if (not include or t.filename in include) and (not exclude or t.filename not in exclude):
-                    output.append("## Launch id: {}".format(d["launch_id"]))
+                    output.append(f"## Launch id: {d['launch_id']}")
                     output.append(str(t))
         if output:
             name = lp.fireworks.find_one({"fw_id": f}, {"name": 1})["name"]
@@ -1103,10 +1103,8 @@ def lpad():
     rerun_fws_parser.add_argument(*launches_mode_args, **launches_mode_kwargs)
     rerun_fws_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input prompt "
-        "required when modifying more than {} "
-        "entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     rerun_fws_parser.add_argument("--task-level", action="store_true", help="Enable task level recovery")
     rerun_fws_parser.add_argument(
@@ -1139,10 +1137,8 @@ def lpad():
     defuse_fw_parser.add_argument(*launches_mode_args, **launches_mode_kwargs)
     defuse_fw_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input prompt "
-        "required when modifying more than {} "
-        "entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     defuse_fw_parser.set_defaults(func=defuse_fws)
 
@@ -1154,10 +1150,8 @@ def lpad():
     pause_fw_parser.add_argument(*launches_mode_args, **launches_mode_kwargs)
     pause_fw_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input "
-        "prompt required when modifying more than {} "
-        "entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     pause_fw_parser.set_defaults(func=pause_fws)
 
@@ -1169,10 +1163,8 @@ def lpad():
     reignite_fw_parser.add_argument(*launches_mode_args, **launches_mode_kwargs)
     reignite_fw_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input "
-        "prompt required when modifying more than {} "
-        "entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     reignite_fw_parser.set_defaults(func=reignite_fws)
 
@@ -1184,10 +1176,8 @@ def lpad():
     resume_fw_parser.add_argument(*launches_mode_args, **launches_mode_kwargs)
     resume_fw_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input "
-        "prompt required when modifying more than {} "
-        "entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     resume_fw_parser.set_defaults(func=resume_fws)
 
@@ -1211,10 +1201,8 @@ def lpad():
     )
     update_fws_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input "
-        "prompt required when modifying more than {} "
-        "entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     update_fws_parser.set_defaults(func=update_fws)
 
@@ -1245,9 +1233,8 @@ def lpad():
     defuse_wf_parser.add_argument(*query_args, **query_kwargs)
     defuse_wf_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input prompt "
-        "required when modifying more than {} entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     defuse_wf_parser.set_defaults(func=pause_wfs)
 
@@ -1258,9 +1245,8 @@ def lpad():
     pause_wf_parser.add_argument(*query_args, **query_kwargs)
     pause_wf_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input prompt "
-        "required when modifying more than {} entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     pause_wf_parser.set_defaults(func=pause_wfs)
 
@@ -1271,10 +1257,8 @@ def lpad():
     reignite_wfs_parser.add_argument(*query_args, **query_kwargs)
     reignite_wfs_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input "
-        "prompt required when modifying more than {} "
-        "entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     reignite_wfs_parser.set_defaults(func=reignite_wfs)
 
@@ -1285,10 +1269,8 @@ def lpad():
     archive_parser.add_argument(*query_args, **query_kwargs)
     archive_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input prompt "
-        "required when modifying more than {} "
-        "entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     archive_parser.set_defaults(func=archive)
 
@@ -1302,10 +1284,8 @@ def lpad():
     delete_wfs_parser.add_argument(*query_args, **query_kwargs)
     delete_wfs_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input prompt "
-        "required when modifying more than {} "
-        "entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     delete_wfs_parser.add_argument(
         "--ldirs",
@@ -1356,10 +1336,8 @@ def lpad():
     priority_parser.add_argument(*launches_mode_args, **launches_mode_kwargs)
     priority_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input prompt "
-        "required when modifying more than {} "
-        "entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     priority_parser.add_argument(
         "-wf", action="store_true", help="the priority will be set for all the fireworks of the matching workflows"
@@ -1479,10 +1457,8 @@ def lpad():
     refresh_parser.add_argument(*query_args, **query_kwargs)
     refresh_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input prompt "
-        "required when modifying more than {} "
-        "entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     refresh_parser.set_defaults(func=refresh)
 
@@ -1495,9 +1471,8 @@ def lpad():
     unlock_parser.add_argument(*query_args, **query_kwargs)
     unlock_parser.add_argument(
         "--password",
-        help="Today's date, e.g. 2012-02-25. "
-        "Password or positive response to input prompt "
-        "required when modifying more than {} entries.".format(PW_CHECK_NUM),
+        help="Today's date, e.g. 2012-02-25. Password or positive response to "
+        f"input prompt required when modifying more than {PW_CHECK_NUM} entries.",
     )
     unlock_parser.set_defaults(func=unlock)
 

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -515,9 +515,9 @@ def detect_lostruns(args):
     if args.display_format is not None and args.display_format != "none":
         print_fws(fi, lp, args)
     if len(ff) > 0 and not args.fizzle and not args.rerun:
-        print("You can fix lost FWs using the --rerun or --fizzle arguments to the " "detect_lostruns command")
+        print("You can fix lost FWs using the --rerun or --fizzle arguments to the detect_lostruns command")
     if len(fi) > 0 and not args.refresh:
-        print("You can fix inconsistent FWs using the --refresh argument to the " "detect_lostruns command")
+        print("You can fix inconsistent FWs using the --refresh argument to the detect_lostruns command")
 
 
 def detect_unreserved(args):
@@ -727,7 +727,7 @@ def webgui(args):
         except ImportError:
             import sys
 
-            sys.exit("Gunicorn is required for server mode. " "Install using `pip install gunicorn`.")
+            sys.exit("Gunicorn is required for server mode. Install using `pip install gunicorn`.")
         nworkers = args.nworkers if args.nworkers else number_of_workers()
         options = {
             "bind": f"{args.host}:{args.port}",
@@ -980,7 +980,7 @@ def lpad():
         "-u",
         "--uri_mode",
         action="store_true",
-        help="Connect via a URI, see: " "https://docs.mongodb.com/manual/reference/connection-string/",
+        help="Connect via a URI, see: https://docs.mongodb.com/manual/reference/connection-string/",
     )
     init_parser.add_argument("--config-file", default=DEFAULT_LPAD_YAML, type=str, help="Filename to write to.")
     init_parser.set_defaults(func=init_yaml)
@@ -996,7 +996,7 @@ def lpad():
 
     addwf_parser = subparsers.add_parser("add", help="insert a Workflow from file")
     addwf_parser.add_argument(
-        "-d", "--dir", action="store_true", help="Directory mode. Finds all files in the " "paths given by wf_file."
+        "-d", "--dir", action="store_true", help="Directory mode. Finds all files in the paths given by wf_file."
     )
     addwf_parser.add_argument("wf_file", nargs="+", help="Path to a Firework or Workflow file")
     addwf_parser.add_argument(
@@ -1042,7 +1042,7 @@ def lpad():
     dump_wf_parser.set_defaults(func=dump_wf)
 
     addscript_parser = subparsers.add_parser(
-        "add_scripts", help="quickly add a script " "(or several scripts) to run in sequence"
+        "add_scripts", help="quickly add a script (or several scripts) to run in sequence"
     )
     addscript_parser.add_argument("scripts", help="Script to run, or space-separated names", nargs="*")
     addscript_parser.add_argument("-n", "--names", help="Firework name, or space-separated names", nargs="*")
@@ -1191,13 +1191,13 @@ def lpad():
         "-u",
         "--update",
         type=str,
-        help="Doc update (enclose pymongo-style dict " "in single-quotes, e.g. '{" '"_tasks.1.hello": "world"}\')',
+        help="Doc update (enclose pymongo-style dict in single-quotes, e.g. '{" '"_tasks.1.hello": "world"}\')',
     )
     update_fws_parser.add_argument(
         "--mongo",
         default=False,
         action="store_true",
-        help="Use full pymongo style dict to modify spec. " "Be very careful as you can break your spec",
+        help="Use full pymongo style dict to modify spec. Be very careful as you can break your spec",
     )
     update_fws_parser.add_argument(
         "--password",
@@ -1218,7 +1218,7 @@ def lpad():
     get_wf_parser.add_argument(
         "-t",
         "--table",
-        help="Print results in table form instead of " "json. Needs prettytable. Works best " 'with "-d less"',
+        help="Print results in table form instead of json. Needs prettytable. Works best " 'with "-d less"',
         action="store_true",
     )
     get_wf_parser.set_defaults(func=get_wfs)
@@ -1289,7 +1289,7 @@ def lpad():
     )
     delete_wfs_parser.add_argument(
         "--ldirs",
-        help="the launch directories associated with the WF will " "be deleted as well, if possible",
+        help="the launch directories associated with the WF will be deleted as well, if possible",
         dest="delete_launch_dirs",
         action="store_true",
     )
@@ -1317,10 +1317,10 @@ def lpad():
     fizzled_parser.add_argument("--rerun", help="rerun lost runs", action="store_true")
     fizzled_parser.add_argument("--refresh", help="refresh the detected inconsistent fireworks", action="store_true")
     fizzled_parser.add_argument(
-        "--max_runtime", help="max runtime, matching failures ran no longer " "than this (seconds)", type=int
+        "--max_runtime", help="max runtime, matching failures ran no longer than this (seconds)", type=int
     )
     fizzled_parser.add_argument(
-        "--min_runtime", help="min runtime, matching failures must have run " "at least this long (seconds)", type=int
+        "--min_runtime", help="min runtime, matching failures must have run at least this long (seconds)", type=int
     )
     fizzled_parser.add_argument("-q", "--query", help="restrict search to only FWs matching this query")
     fizzled_parser.add_argument("-lq", "--launch_query", help="restrict search to only launches matching this query")
@@ -1345,7 +1345,7 @@ def lpad():
     priority_parser.set_defaults(func=set_priority)
 
     parser.add_argument(
-        "-l", "--launchpad_file", help="path to LaunchPad file containing " "central DB connection info", default=None
+        "-l", "--launchpad_file", help="path to LaunchPad file containing central DB connection info", default=None
     )
     parser.add_argument(
         "-c",
@@ -1363,14 +1363,14 @@ def lpad():
         dest="port",
         type=int,
         default=WEBSERVER_PORT,
-        help="Port to run the web server on (default: 5000 or WEBSERVER_PORT arg in " "FW_config.yaml)",
+        help="Port to run the web server on (default: 5000 or WEBSERVER_PORT arg in FW_config.yaml)",
     )
     webgui_parser.add_argument(
         "--host",
         dest="host",
         type=str,
         default=WEBSERVER_HOST,
-        help="Host to run the web server on (default: 127.0.0.1 or WEBSERVER_HOST arg in " "FW_config.yaml)",
+        help="Host to run the web server on (default: 127.0.0.1 or WEBSERVER_HOST arg in FW_config.yaml)",
     )
     webgui_parser.add_argument("--debug", help="print debug messages", action="store_true")
     webgui_parser.add_argument(
@@ -1392,7 +1392,7 @@ def lpad():
     recover_parser.add_argument(
         "-w",
         "--fworker_file",
-        help="path to fworker file. An empty string " "will match all the workers",
+        help="path to fworker file. An empty string will match all the workers",
         default=FWORKER_LOC,
     )
     recover_parser.add_argument("-pe", "--print-errors", help="print errors", action="store_true")
@@ -1434,22 +1434,22 @@ def lpad():
     orphaned_parser.add_argument("--remove", help="delete orphaned", action="store_true")
     orphaned_parser.add_argument(
         "--ldirs",
-        help="the launch directories " "associated with the orphaned Fireworks will " "be deleted as well, if possible",
+        help="the launch directories associated with the orphaned Fireworks will be deleted as well, if possible",
         dest="delete_launch_dirs",
         action="store_true",
     )
     orphaned_parser.set_defaults(func=orphaned)
 
     tuneup_parser = admin_subparser.add_parser(
-        "tuneup", help="Tune-up the database (should be performed during " "scheduled downtime)"
+        "tuneup", help="Tune-up the database (should be performed during scheduled downtime)"
     )
     tuneup_parser.add_argument(
-        "--full", help="Run full tuneup and compaction (should be run during " "DB downtime only)", action="store_true"
+        "--full", help="Run full tuneup and compaction (should be run during DB downtime only)", action="store_true"
     )
     tuneup_parser.set_defaults(func=tuneup)
 
     refresh_parser = admin_subparser.add_parser(
-        "refresh", help="manually force a workflow refresh " "(not usually needed)"
+        "refresh", help="manually force a workflow refresh (not usually needed)"
     )
     refresh_parser.add_argument(*fw_id_args, **fw_id_kwargs)
     refresh_parser.add_argument("-n", "--name", help="name")
@@ -1463,7 +1463,7 @@ def lpad():
     refresh_parser.set_defaults(func=refresh)
 
     unlock_parser = admin_subparser.add_parser(
-        "unlock", help="manually unlock a workflow that is " "locked (only if you know what you are doing!)"
+        "unlock", help="manually unlock a workflow that is locked (only if you know what you are doing!)"
     )
     unlock_parser.add_argument(*fw_id_args, **fw_id_kwargs)
     unlock_parser.add_argument("-n", "--name", help="name")
@@ -1482,7 +1482,7 @@ def lpad():
     report_parser.add_argument(
         "-c",
         "--collection",
-        help="The collection to report on; " "choose from 'fws' (default), " "'wflows', or 'launches'.",
+        help="The collection to report on; choose from 'fws' (default), 'wflows', or 'launches'.",
         default="fws",
     )
     report_parser.add_argument(
@@ -1494,11 +1494,9 @@ def lpad():
         default="days",
     )
     report_parser.add_argument(
-        "-n", "--num_intervals", help="The number of intervals on which to " "report (default=5)", type=int, default=5
+        "-n", "--num_intervals", help="The number of intervals on which to report (default=5)", type=int, default=5
     )
-    report_parser.add_argument(
-        "-q", "--query", help="Additional Pymongo queries to filter entries " "before processing."
-    )
+    report_parser.add_argument("-q", "--query", help="Additional Pymongo queries to filter entries before processing.")
     report_parser.set_defaults(func=report)
 
     introspect_parser = subparsers.add_parser("introspect", help="Introspect recent runs to pin down errors")

--- a/fireworks/scripts/mlaunch_run.py
+++ b/fireworks/scripts/mlaunch_run.py
@@ -41,7 +41,7 @@ def mlaunch():
     parser.add_argument(
         "-c",
         "--config_dir",
-        help="path to a directory containing the config file " "(used if -l, -w unspecified)",
+        help="path to a directory containing the config file (used if -l, -w unspecified)",
         default=CONFIG_FILE_DIR,
     )
 
@@ -50,7 +50,7 @@ def mlaunch():
 
     parser.add_argument(
         "--nodefile",
-        help="nodefile name or environment variable name containing " "the node file name (for populating FWData only)",
+        help="nodefile name or environment variable name containing the node file name (for populating FWData only)",
         default=None,
         type=str,
     )

--- a/fireworks/scripts/qlaunch_run.py
+++ b/fireworks/scripts/qlaunch_run.py
@@ -263,7 +263,7 @@ def qlaunch():
         else:
             do_launch(args)
         if interval > 0:
-            print("Next run in {} seconds... Press Ctrl-C to exit at any " "time.".format(interval))
+            print(f"Next run in {interval} seconds... Press Ctrl-C to exit at any time.")
             time.sleep(args.daemon)
         else:
             break

--- a/fireworks/scripts/qlaunch_run.py
+++ b/fireworks/scripts/qlaunch_run.py
@@ -108,7 +108,7 @@ def qlaunch():
         "-rh",
         "--remote_host",
         nargs="*",
-        help="Remote host to exec qlaunch. Right now, " "only supports running from a config dir.",
+        help="Remote host to exec qlaunch. Right now, only supports running from a config dir.",
     )
     parser.add_argument(
         "-rc",
@@ -146,19 +146,19 @@ def qlaunch():
     parser.add_argument(
         "-rs",
         "--remote_setup",
-        help="Setup the remote config dir using files in " "the directory specified by -c.",
+        help="Setup the remote config dir using files in the directory specified by -c.",
         action="store_true",
     )
     parser.add_argument(
         "-d",
         "--daemon",
-        help="Daemon mode. Command is repeated every x " "seconds. Defaults to 0, which means non-daemon " "mode.",
+        help="Daemon mode. Command is repeated every x seconds. Defaults to 0, which means non-daemon mode.",
         type=int,
         default=0,
     )
     parser.add_argument("--launch_dir", help="directory to launch the job / rapid-fire", default=".")
     parser.add_argument(
-        "--block_dir", help="directory to use as block dir. Can be a new or existing " "block. Must start with 'block_'"
+        "--block_dir", help="directory to use as block dir. Can be a new or existing block. Must start with 'block_'"
     )
     parser.add_argument("--logdir", help="path to a directory for logging", default=None)
     parser.add_argument("--loglvl", help="level to print log messages", default="INFO")

--- a/fireworks/scripts/rlaunch_run.py
+++ b/fireworks/scripts/rlaunch_run.py
@@ -59,7 +59,7 @@ def rlaunch():
     )
     rapid_parser.add_argument(
         "--max_loops",
-        help="after this many sleep loops, quit even in " "infinite nlaunches mode (default -1 is infinite loops)",
+        help="after this many sleep loops, quit even in infinite nlaunches mode (default -1 is infinite loops)",
         default=-1,
         type=int,
     )
@@ -77,7 +77,7 @@ def rlaunch():
         default=0,
     )
     multi_parser.add_argument(
-        "--sleep", help="sleep time between loops in infinite launch mode" "(secs)", default=None, type=int
+        "--sleep", help="sleep time between loops in infinite launch mode (secs)", default=None, type=int
     )
     multi_parser.add_argument(
         "--timeout", help="timeout (secs) after which to quit (default None)", default=None, type=int
@@ -92,7 +92,7 @@ def rlaunch():
     )
     multi_parser.add_argument("--ppn", help="processors per node (for populating FWData only)", default=1, type=int)
     multi_parser.add_argument(
-        "--exclude_current_node", help="Don't use the script launching node" "as compute node", action="store_true"
+        "--exclude_current_node", help="Don't use the script launching node as compute node", action="store_true"
     )
     multi_parser.add_argument(
         "--local_redirect", help="Redirect stdout and stderr to the launch directory", action="store_true"
@@ -103,7 +103,7 @@ def rlaunch():
     parser.add_argument(
         "-c",
         "--config_dir",
-        help="path to a directory containing the config file " "(used if -l, -w unspecified)",
+        help="path to a directory containing the config file (used if -l, -w unspecified)",
         default=CONFIG_FILE_DIR,
     )
 

--- a/fireworks/scripts/rlaunch_run.py
+++ b/fireworks/scripts/rlaunch_run.py
@@ -12,11 +12,7 @@ from fireworks.core.launchpad import LaunchPad
 from fireworks.core.rocket_launcher import launch_rocket, rapidfire
 from fireworks.features.multi_launcher import launch_multiprocess
 from fireworks.fw_config import CONFIG_FILE_DIR, FWORKER_LOC, LAUNCHPAD_LOC
-from fireworks.utilities.fw_utilities import (
-    get_fw_logger,
-    get_my_host,
-    get_my_ip,
-)
+from fireworks.utilities.fw_utilities import get_fw_logger, get_my_host, get_my_ip
 
 __author__ = "Anubhav Jain"
 __credits__ = "Xiaohui Qu, Shyam Dwaraknath"
@@ -28,7 +24,7 @@ __date__ = "Feb 7, 2013"
 
 
 def handle_interrupt(signum, frame):
-    sys.stderr.write(f"Interruped by signal {signum:d}\n")
+    sys.stderr.write(f"Interrupted by signal {signum:d}\n")
     sys.exit(1)
 
 

--- a/fireworks/tests/multiprocessing_tests.py
+++ b/fireworks/tests/multiprocessing_tests.py
@@ -34,7 +34,7 @@ class TestCheckoutFW(TestCase):
             cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl="ERROR")
             cls.lp.reset(password=None, require_password=False)
         except Exception:
-            raise unittest.SkipTest("MongoDB is not running in localhost:" "27017! Skipping tests.")
+            raise unittest.SkipTest("MongoDB is not running in localhost: 27017! Skipping tests.")
 
     @classmethod
     def tearDownClass(cls):
@@ -82,7 +82,7 @@ class TestEarlyExit(TestCase):
             cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl="ERROR")
             cls.lp.reset(password=None, require_password=False)
         except Exception:
-            raise unittest.SkipTest("MongoDB is not running in localhost:" "27017! Skipping tests.")
+            raise unittest.SkipTest("MongoDB is not running in localhost:27017! Skipping tests.")
 
     @classmethod
     def tearDownClass(cls):

--- a/fireworks/user_objects/firetasks/dataflow_tasks.py
+++ b/fireworks/user_objects/firetasks/dataflow_tasks.py
@@ -309,7 +309,7 @@ class ForeachTask(FireTaskBase):
             spec[self["split"]] = chunk
             task = load_object(self["task"])
             task["chunk_number"] = index
-            name = self._fw_name + " " + str(index)
+            name = f"{self._fw_name} {index}"
             fireworks.append(Firework(task, spec=spec, name=name))
         return FWAction(detours=fireworks)
 

--- a/fireworks/user_objects/firetasks/fileio_tasks.py
+++ b/fireworks/user_objects/firetasks/fileio_tasks.py
@@ -156,8 +156,7 @@ class FileTransferTask(FiretaskBase):
 
                 elif not ignore_errors:
                     raise ValueError(
-                        "There was an error performing operation {} from {} "
-                        "to {}".format(mode, self["files"], self["dest"])
+                        f"There was an error performing operation {mode} from {self['files']} to {self['dest']}"
                     )
 
         if mode == "rtransfer":

--- a/fireworks/user_objects/firetasks/filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/filepad_tasks.py
@@ -90,7 +90,7 @@ class GetFilesByQueryTask(FiretaskBase):
     Required params:
         - query (dict): mongo db query identifying files to fetch.
           Same as within fireworks.utilities.dict_mods, use '->' in dict keys
-          for querying nested documents, instead of MongoDB '.' (dot) seperator.
+          for querying nested documents, instead of MongoDB '.' (dot) separator.
           Do use '.' and NOT '->' within the 'sort_key' field.
 
     Optional params:

--- a/fireworks/user_objects/firetasks/filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/filepad_tasks.py
@@ -36,7 +36,7 @@ class AddFilesTask(FiretaskBase):
         if isinstance(self["paths"], list):
             paths = [os.path.abspath(p) for p in self["paths"]]
         else:
-            paths = [os.path.abspath(p) for p in glob("{}/{}".format(directory, self["paths"]))]
+            paths = [os.path.abspath(p) for p in glob(f"{directory}/{self['paths']}")]
 
         # if not given, use the full paths as identifiers
         identifiers = self.get("identifiers", paths)
@@ -175,9 +175,8 @@ class GetFilesByQueryTask(FiretaskBase):
             file_name = new_file_names[i] if new_file_names else doc["original_file_name"]
             if fizzle_degenerate_file_name and (file_name in unique_file_names):
                 raise ValueError(
-                    " ".join(
-                        ("The local file name {:s} is used", "a second time by result {:d}/{:d}! (query: {:s})")
-                    ).format(file_name, i, len(l), json.dumps(query))
+                    f"The local file name {file_name} is used a second time by result {i}/{len(l)}! "
+                    f"(query: {json.dumps(query)})"
                 )
 
             unique_file_names.add(file_name)

--- a/fireworks/user_objects/firetasks/script_task.py
+++ b/fireworks/user_objects/firetasks/script_task.py
@@ -133,7 +133,7 @@ class PyTask(FiretaskBase):
     Runs any python function! Extremely powerful, which allows you to
     essentially run any accessible method on the system. The optional inputs
     and outputs lists may contain spec keys to add to args list and to make
-    the function output available in the curent and in children fireworks.
+    the function output available in the current and in children fireworks.
 
     Required parameters:
         - func (str): Fully qualified python method. E.g., json.dump, or shutil

--- a/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
@@ -137,7 +137,7 @@ class FilePadTasksTest(unittest.TestCase):
         # test successful if exception raised
 
     def test_getfilesbyquerytask_ignore_degenerate_file_name(self):
-        """Tests on ignoring degenrate file name in result from FilePad query"""
+        """Tests on ignoring degenerate file name in result from FilePad query"""
         with open("degenerate_file.txt", "w") as f:
             f.write("Some file with some content")
         t = AddFilesTask(paths=["degenerate_file.txt"], identifiers=["some_identifier"], metadata={"key": "value"})

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -83,7 +83,7 @@ class CommonAdapter(QueueAdapterBase):
             # 99% of the time you just get:
             # Cobalt: "199768"
             # but there's a version that also includes project and queue
-            # information on preceeding lines and both of those  might
+            # information on preceding lines and both of those  might
             # contain a number in any position.
             re_string = r"(\b\d+\b)"
         else:
@@ -130,7 +130,7 @@ class CommonAdapter(QueueAdapterBase):
         # TODO: what if username is too long for the output and is cut off?
 
         # WRS: I may come back to this after confirming that Cobalt
-        #      strictly follows the PBS standard and replace the spliting
+        #      strictly follows the PBS standard and replace the splitting
         #      with a regex that would solve length issues
 
         if self.q_type == "SLURM":
@@ -237,7 +237,7 @@ class CommonAdapter(QueueAdapterBase):
 
     def get_njobs_in_queue(self, username=None):
         """
-        returns the number of jobs currently in the queu efor the user
+        returns the number of jobs currently in the queue for the user
 
         :param username: (str) the username of the jobs to count (default is to autodetect)
         :return: (int) number of jobs in the queue

--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -55,8 +55,7 @@ class CommonAdapter(QueueAdapterBase):
         """
         if q_type not in CommonAdapter.default_q_commands:
             raise ValueError(
-                "{} is not a supported queue type. "
-                "CommonAdaptor supports {}".format(q_type, list(self.default_q_commands.keys()))
+                f"{q_type} is not a supported queue type. CommonAdaptor supports {list(self.default_q_commands.keys())}"
             )
         self.q_type = q_type
         self.template_file = (

--- a/fireworks/user_objects/queue_adapters/tests/test_common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/tests/test_common_adapter.py
@@ -13,10 +13,7 @@ __date__ = "12/31/13"
 import unittest
 
 from fireworks.user_objects.queue_adapters.common_adapter import *
-from fireworks.utilities.fw_serializers import (
-    load_object,
-    load_object_from_file,
-)
+from fireworks.utilities.fw_serializers import load_object, load_object_from_file
 
 
 class CommonAdapterTest(unittest.TestCase):
@@ -30,7 +27,7 @@ class CommonAdapterTest(unittest.TestCase):
         )
         p_new = load_object(p.to_dict())
 
-        # Make sure the original and deserialized verison both work properly.
+        # Make sure the original and deserialized version both work properly.
         for a in [p, p_new]:
             script = a.get_script_str("here")
             lines = script.split("\n")

--- a/fireworks/utilities/dagflow.py
+++ b/fireworks/utilities/dagflow.py
@@ -189,7 +189,7 @@ class DAGFlow(Graph):
         if entity in step["data"] and entity not in csrclist:
             lst.append(step.index)
 
-        # data entity from a preceeding task in the same step
+        # data entity from a preceding task in the same step
         outp_found = False
         for task in step["_tasks"]:
             if "outputs" in task and entity in task["outputs"]:

--- a/fireworks/utilities/fw_utilities.py
+++ b/fireworks/utilities/fw_utilities.py
@@ -10,12 +10,7 @@ import sys
 import traceback
 from multiprocessing.managers import BaseManager
 
-from fireworks.fw_config import (
-    DS_PASSWORD,
-    FW_BLOCK_FORMAT,
-    FW_LOGGING_FORMAT,
-    FWData,
-)
+from fireworks.fw_config import DS_PASSWORD, FW_BLOCK_FORMAT, FW_LOGGING_FORMAT, FWData
 
 __author__ = "Anubhav Jain, Xiaohui Qu"
 __copyright__ = "Copyright 2012, The Materials Project"
@@ -263,7 +258,7 @@ def plot_wf(
         wf (Workflow): workflow object.
         depth_factor (float): adjust this to stretch the plot in y direction.
         breadth_factor (float): adjust this to stretch the plot in x direction.
-        labels_on (bool): whether to label the nodes or not. The default is to lable the nodes
+        labels_on (bool): whether to label the nodes or not. The default is to label the nodes
             using the firework names.
         numerical_label (bool): set this to label the nodes using the firework ids.
         text_loc_factor (float): adjust the label location.

--- a/fireworks/utilities/tests/test_update_collection.py
+++ b/fireworks/utilities/tests/test_update_collection.py
@@ -42,7 +42,7 @@ class UpdateCollectionTests(unittest.TestCase):
         cls.assertEqual(ndocs, 1)
         test_doc = cls.lp.db.test_coll.find_one({"foo": "bar"})
         cls.assertEqual(test_doc["foo_list"][1]["foo2"], "foo/new/path/bar")
-        test_doc_archived = cls.lp.db["{}_xiv_{}".format("test_coll", datetime.date.today())].find_one()
+        test_doc_archived = cls.lp.db[f"test_coll_xiv_{datetime.date.today()}"].find_one()
         cls.assertEqual(test_doc_archived["foo_list"][1]["foo2"], "foo/old/path/bar")
 
 

--- a/fireworks/utilities/update_collection.py
+++ b/fireworks/utilities/update_collection.py
@@ -40,7 +40,7 @@ def update_path_in_collection(db, collection_name, replacements, query=None, dry
         query (dict): criteria for query, default None if you want all documents to be updated
         dry_run (bool): if True, only a new collection with new paths is created and original "collection" is not
             replaced
-        force_clear (bool): careful! If True, the collection "{}_temp_refactor".format(collection) is removed!
+        force_clear (bool): careful! If True, the collection f"{collection}_temp_refactor" is removed!
     Returns:
          None, but if dry_run==False it replaces the collection with the updated one
     """

--- a/fw_tutorials/dynamic_wf/printjob_task.py
+++ b/fw_tutorials/dynamic_wf/printjob_task.py
@@ -18,6 +18,6 @@ class PrintJobTask(FiretaskBase):
         job_info_array = fw_spec["_job_info"]
         prev_job_info = job_info_array[-1]
 
-        print("The name of the previous job was: {}".format(prev_job_info["name"]))
-        print("The id of the previous job was: {}".format(prev_job_info["fw_id"]))
-        print("The location of the previous job was: {}".format(prev_job_info["launch_dir"]))
+        print(f"The name of the previous job was: {prev_job_info['name']}")
+        print(f"The id of the previous job was: {prev_job_info['fw_id']}")
+        print(f"The location of the previous job was: {prev_job_info['launch_dir']}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,7 @@ statistics = True
 exclude=*test*,docs_rst/*.py,fireworks/__init__.py
 
 [isort]
-multi_line_output = 3
-include_trailing_comma = True
+profile = black
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Only the first two commits in this PR are actual fixes.

The other two are just
- upgrading the remaining `"".format()` strings to f-strings (which make errors like that fixed in 2nd commit impossible) (not sure why `pyupgrade` left some of them) and
- joining awkwardly split strings (e.g. ``"Gunicorn is required for server mode. " "Install using `pip install gunicorn`."`` -> ``"Gunicorn is required for server mode. Install using `pip install gunicorn`."``).