### PR TITLE
Reduce default number of webgui workers to 1

### DIFF
--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -720,18 +720,14 @@ def webgui(args):
         p1.join()
     else:
         try:
-            from fireworks.flask_site.gunicorn import (
-                StandaloneApplication,
-                number_of_workers,
-            )
+            from fireworks.flask_site.gunicorn import StandaloneApplication
         except ImportError:
             import sys
 
             sys.exit("Gunicorn is required for server mode. Install using `pip install gunicorn`.")
-        nworkers = args.nworkers if args.nworkers else number_of_workers()
         options = {
             "bind": f"{args.host}:{args.port}",
-            "workers": nworkers,
+            "workers": args.nworkers,
         }
         StandaloneApplication(app, options).run()
 
@@ -877,10 +873,11 @@ def get_output_func(format):
 def arg_positive_int(value):
     try:
         ivalue = int(value)
-        if ivalue < 1:
-            raise ValueError()
     except ValueError:
-        raise ArgumentTypeError(f"{value} is not a positive integer")
+        raise ArgumentTypeError(f"int(value) conversion failed for {value}")
+
+    if ivalue < 1:
+        raise ValueError(f"{value} is not a positive integer")
     return ivalue
 
 
@@ -1376,7 +1373,9 @@ def lpad():
     webgui_parser.add_argument(
         "-s", "--server_mode", help="run in server mode (skip opening the browser)", action="store_true"
     )
-    webgui_parser.add_argument("--nworkers", type=arg_positive_int, help="Number of worker processes for server mode")
+    webgui_parser.add_argument(
+        "--nworkers", type=arg_positive_int, help="Number of worker processes for server mode", default=1
+    )
     webgui_parser.add_argument("--fwquery", help="additional query filter for FireWorks as JSON string")
     webgui_parser.add_argument("--wflowquery", help="additional query filter for Workflows as JSON string")
     webgui_parser.add_argument(

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -883,7 +883,7 @@ def arg_positive_int(value):
 
 def lpad():
     m_description = (
-        "A command line interface to FireWorks. For more help on a specific command, " 'type "lpad <command> -h".'
+        "A command line interface to FireWorks. For more help on a specific command, type 'lpad <command> -h'."
     )
 
     parser = ArgumentParser(description=m_description)
@@ -910,7 +910,7 @@ def lpad():
     state_kwargs = {
         "type": lambda s: s.upper(),
         "help": "Select by state.",
-        "choices": list(Firework.STATE_RANKS.keys()),
+        "choices": Firework.STATE_RANKS,
     }
     disp_args = ["-d", "--display_format"]
     disp_kwargs = {
@@ -1007,9 +1007,8 @@ def lpad():
 
     get_launchdir_parser = subparsers.add_parser(
         "get_launchdir",
-        help="get the directory of the most recent launch of the given fw_id."
-        ' A common usage is "cd `get_launchdir <FW_ID>`" to change the '
-        "working directory that of the FW launch",
+        help="get the directory of the most recent launch of the given fw_id. A common usage is "
+        "'cd `get_launchdir <FW_ID>`' to change the working directory to that of the FW launch",
     )
     get_launchdir_parser.add_argument("fw_id", type=int, help="fw_id to chdir to")
     get_launchdir_parser.add_argument(


### PR DESCRIPTION
Closes #467.

Did some local testing with this new default and found a faster startup time but no noticeable degrade in the GUI's performance. Tested on a DB with ~5400 fireworks.