### PR TITLE
Fix importlib import

### DIFF
--- a/docs_rst/conf.py
+++ b/docs_rst/conf.py
@@ -10,16 +10,20 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import importlib.metadata
 import os
 import sys
+
+if sys.version_info < (3, 8):
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.append(os.path.abspath(".."))
 print(sys.path)
-fw_version = importlib.metadata.version("fireworks")
+fw_version = metadata.version("fireworks")
 
 # -- General configuration -----------------------------------------------------
 

--- a/tasks.py
+++ b/tasks.py
@@ -1,14 +1,19 @@
 # Copyright (c) Pymatgen Development Team.
 # Distributed under the terms of the MIT License.
 
-import importlib.metadata
 import json
 import os
+import sys
 import webbrowser
 
 import requests
 from invoke import task
 from monty.os import cd
+
+if sys.version_info < (3, 8):
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata
 
 """
 Deployment file to facilitate releases.
@@ -17,7 +22,7 @@ Deployment file to facilitate releases.
 __author__ = "Shyue Ping Ong, Anubhav Jain"
 __email__ = "ongsp@ucsd.edu"
 __date__ = "Sep 1, 2014"
-fw_version = f"v{importlib.metadata.version('fireworks')}"
+fw_version = f"v{metadata.version('fireworks')}"
 
 
 @task


### PR DESCRIPTION
Overlooked 2 files in #478 that still use the py38-only way of importing `importlib.metadata`.