### PR TITLE
qlaunch not working on a fresh install

### DIFF
--- a/fireworks/utilities/fw_serializers.py
+++ b/fireworks/utilities/fw_serializers.py
@@ -359,7 +359,7 @@ def load_object(obj_dict):
                 import warnings
 
                 warnings.warn(f"{m_object} in {mod_name} cannot be loaded because of {str(ex)}. Skipping..")
-                traceback.print_exc(ex)
+                traceback.print_exc()
 
     if len(found_objects) == 1:
         SAVED_FW_MODULES[fw_name] = found_objects[0][1]


### PR DESCRIPTION
# qlaunch not working on a fresh install

It appears a `pytest` import was added in the path of `USER_PACKAGES`

https://github.com/materialsproject/fireworks/blob/51aa296dff9cd0411ad9165973dd4bc5c4a5c7aa/fireworks/fw_config.py#L20

And the part of the code that is meant to deal with the exception has a call to `traceback.print_exc(ex)`
which is treating the `ex` exception as the `limit` parameter. 

https://github.com/materialsproject/fireworks/blob/635fca928777610e5933a4f197c0be024aaa82ef/fireworks/utilities/fw_serializers.py#L362

Code for `print_exc`:
```
Signature: traceback.print_exc(limit=None, file=None, chain=True)
Source:   
def print_exc(limit=None, file=None, chain=True):
    """Shorthand for 'print_exception(*sys.exc_info(), limit, file)'."""
    print_exception(*sys.exc_info(), limit=limit, file=file, chain=chain)
File:      ~/miniconda3/envs/mp/lib/python3.9/traceback.py
Type:      function
```

Full output of the error
```
/g/g20/shen9/repos/mp/fireworks/fireworks/utilities/fw_serializers.py:361: UserWarning: None in fireworks.utilities.tests.test_visualize cannot be loaded because of No module named 'pytest'. Skipping..
  warnings.warn(f"{m_object} in {mod_name} cannot be loaded because of {str(ex)}. Skipping..")
Traceback (most recent call last):
  File "/g/g20/shen9/repos/mp/fireworks/fireworks/utilities/fw_serializers.py", line 354, in load_object
    m_module = importlib.import_module(mod_name)
  File "/g/g20/shen9/.conda/envs/mp2/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/g/g20/shen9/repos/mp/fireworks/fireworks/utilities/tests/test_visualize.py", line 1, in <module>
    import pytest
ModuleNotFoundError: No module named 'pytest'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/g/g20/shen9/.conda/envs/mp2/bin/qlaunch", line 33, in <module>
    sys.exit(load_entry_point('FireWorks', 'console_scripts', 'qlaunch')())
  File "/g/g20/shen9/repos/mp/fireworks/fireworks/scripts/qlaunch_run.py", line 272, in qlaunch
    do_launch(args)
  File "/g/g20/shen9/repos/mp/fireworks/fireworks/scripts/qlaunch_run.py", line 61, in do_launch
    queueadapter = load_object_from_file(args.queueadapter_file)
  File "/g/g20/shen9/repos/mp/fireworks/fireworks/utilities/fw_serializers.py", line 397, in load_object_from_file
    return load_object(reconstitute_dates(dct))
  File "/g/g20/shen9/repos/mp/fireworks/fireworks/utilities/fw_serializers.py", line 362, in load_object
    traceback.print_exc(ex)
  File "/g/g20/shen9/.conda/envs/mp2/lib/python3.9/traceback.py", line 163, in print_exc
    print_exception(*sys.exc_info(), limit=limit, file=file, chain=chain)
  File "/g/g20/shen9/.conda/envs/mp2/lib/python3.9/traceback.py", line 103, in print_exception
    for line in TracebackException(
  File "/g/g20/shen9/.conda/envs/mp2/lib/python3.9/traceback.py", line 517, in __init__
    self.stack = StackSummary.extract(
  File "/g/g20/shen9/.conda/envs/mp2/lib/python3.9/traceback.py", line 340, in extract
    if limit >= 0:
TypeError: '>=' not supported between instances of 'ModuleNotFoundError' and 'int'
```