### PR TITLE
Update common_adapter.py

### DIFF
--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -249,7 +249,7 @@ class CommonAdapter(QueueAdapterBase):
 
         # run qstat
         qstat = Command(self._get_status_cmd(username))
-        p = qstat.run(timeout=self.timeout)
+        p = qstat.run(timeout=self.timeout, shell=True)
 
         # parse the result
         if p[0] == 0:


### PR DESCRIPTION
add: shell=True for Command run

I want to use arguments for status_cmd, but they are not accepted if shell=True is not set. An example is as follows:
_q_commands_override:
    submit_cmd: qsub
    status_cmd: qstat -q particular_queue.q

See also
https://stackoverflow.com/questions/30010939/subprocess-popen-error-no-such-file-or-directory-when-calling-command-with-a