### PR TITLE
Fix using URI mode to provide DB info

### DIFF
--- a/docs_rst/installation.rst
+++ b/docs_rst/installation.rst
@@ -11,7 +11,7 @@ FireWorks requires a single MongoDB instance to store and access your workflows.
 
 To install MongoDB *locally*, follow the instructions at `MongoDB <http://www.mongodb.org>`_. This is pretty simple and typically works well if everything you do is confined to your local machine (or for first learning FireWorks locally), but configuration for access from outside machines can be tricky.
 
-To access via a *cloud provider*, you might try `MongoDB Atlas <https://www.mongodb .com/cloud/atlas>`_ or search for a different one. If you are using MongoDB Atlas, here are a few notes:
+To access via a *cloud provider*, you might try `MongoDB Atlas <https://www.mongodb.com/cloud/atlas>`_ or search for a different one. If you are using MongoDB Atlas, here are a few notes:
 
     * Set up an account via the MongoDB Atlas website instructions. When asked to pick a cluster type, you can just choose the *Shared Cluster* free option of 500MB. This is more than enough to get started.
     * MongoDB Atlas will ask you to create a database; any name is fine, but make sure you write down what it is.

--- a/docs_rst/installation.rst
+++ b/docs_rst/installation.rst
@@ -11,11 +11,12 @@ FireWorks requires a single MongoDB instance to store and access your workflows.
 
 To install MongoDB *locally*, follow the instructions at `MongoDB <http://www.mongodb.org>`_. This is pretty simple and typically works well if everything you do is confined to your local machine (or for first learning FireWorks locally), but configuration for access from outside machines can be tricky.
 
-To access via a *cloud provider*, you might try `mLab <http://mlab.com/>`_, `MongoDB Atlas <https://www.mongodb.com/cloud/atlas>`_, or search for a different one. If you are using mLab, here are a few notes:
+To access via a *cloud provider*, you might try `MongoDB Atlas <https://www.mongodb .com/cloud/atlas>`_ or search for a different one. If you are using MongoDB Atlas, here are a few notes:
 
-    * Set up an account via the mLab web site instructions. When asked to pick a server type (e.g. Amazon, Google, etc) you can just choose free option of 500MB. This is more than enough to get started.
-    * mLab will ask you to create a database; any name is fine, but make sure you write down what it is.
+    * Set up an account via the MongoDB Atlas website instructions. When asked to pick a cluster type, you can just choose the *Shared Cluster* free option of 500MB. This is more than enough to get started.
+    * MongoDB Atlas will ask you to create a database; any name is fine, but make sure you write down what it is.
     * After creating a database, note that you'll need to create at least one database user in order to access the database.
+    * You'll also need to add your IP address to the IP access list before you can connect to your cluster.
     * You can test your database connection using MongoDB's built-in command line tools. Or, you can continue with FireWorks installation and subsequently the tutorials, which will test the database connection as part of the procedure.
 
 Preparing to Install FireWorks (Python and pip)
@@ -127,7 +128,13 @@ We've set up a test database to see if you can connect to it.
     username: test_user
     password: testing123
 
-Note: If using a MongoDB URI (e.g. mongodb+srv://<username>:<password>@host/MyDBName), provide this as the `host`, exclude the `username` and `password`, and make sure to set `uri_store: true`.
+Alternatively, with a MongoDB URI (e.g. when using MongoDB Atlas), you need to provide::
+
+    host: mongodb+srv://<username>:<password>@cluster0.z1sow.mongodb.net
+    name: fireworks
+    uri_mode: true
+
+Replace ``mongodb+srv://<username>:<password>@cluster0.z1sow.mongodb.net`` by your MongoDB URI, and don't forget to also replace ``<username>`` and ``<password>`` by your own credentials.
 
 2. Execute the command::
 

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -207,8 +207,9 @@ class LaunchPad(FWSerializable):
         # get connection
         if uri_mode:
             self.connection = MongoClient(host, **self.mongoclient_kwargs)
-            dbname = host.split("/")[-1].split("?")[0]  # parse URI to extract dbname
-            self.db = self.connection[dbname]
+            if self.name is None:
+                raise ValueError("Must specify a database name when using a MongoDB URI string.")
+            self.db = self.connection[self.name]
         else:
             self.connection = MongoClient(
                 self.host,


### PR DESCRIPTION
Previous code and docs for using the URI mode of a DB is based on mLab, which has been acquired by MongoDB Atlas. This PR fixes the URI mode. 

- now, when using the URI mode, the database name need to be explicitly provided 
- updated the corresponding docs  