### PR TITLE
Add GPU Support for rlaunch multi

### DIFF
--- a/fireworks/features/multi_launcher.py
+++ b/fireworks/features/multi_launcher.py
@@ -251,19 +251,19 @@ def launch_multiprocess(
         exclude_current_node: Don't use the script launching node as a compute node
         local_redirect (bool): redirect standard input and output to local file
     """
+    gpus_per_node = None
     if use_gpu:
         # Count the number of GPUs on each node
         gpus_per_node = len(os.environ["CUDA_VISIBLE_DEVICES"].split(','))
+        num_gpu = gpus_per_node
         if total_node_list is not None:
             # If the node list is specified, we need to multiply the number of GPUs by the
             # number of nodes. Else we assume it is a single node job.
             num_gpu = gpus_per_node * len(total_node_list)
-        else:
-            num_gpu = gpus_per_node
         if num_jobs > num_gpu:
             raise ValueError(f"More jobs than GPUs requested. num_jobs={num_jobs},"
                              f" num_gpu={num_gpu * len(total_node_list)}")
-            
+
     # parse node file contents
     if exclude_current_node:
         host = get_my_host()

--- a/fireworks/features/multi_launcher.py
+++ b/fireworks/features/multi_launcher.py
@@ -78,7 +78,7 @@ def rapidfire_process(
         # If the sub job is using GPU, set the CUDA_VISIBLE_DEVICES environment variable
         # This will limit the GPU usage to only the specified GPU
         os.environ['CUDA_VISIBLE_DEVICES'] = str(gpu_id)
-
+    print('CUDA_VISIBLE_DEVICES', os.environ.get('CUDA_VISIBLE_DEVICES', None))
     ds = DataServer(address=("127.0.0.1", port), authkey=DS_PASSWORD)
     ds.connect()
     launchpad = ds.LaunchPad()
@@ -255,7 +255,8 @@ def launch_multiprocess(
         local_redirect (bool): redirect standard input and output to local file
     """
     gpus_per_node = None
-    if use_gpu:
+    cuda_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+    if use_gpu and cuda_devices is not None:
         # Count the number of GPUs on each node
         gpus_per_node = len(os.environ["CUDA_VISIBLE_DEVICES"].split(','))
         num_gpu = gpus_per_node
@@ -265,8 +266,7 @@ def launch_multiprocess(
             num_gpu = gpus_per_node * len(total_node_list)
         if num_jobs > num_gpu:
             raise ValueError(f"More jobs than GPUs requested. num_jobs={num_jobs},"
-                             f" num_gpu={num_gpu * len(total_node_list)}")
-
+                             f" num_gpu={num_gpu}")
     # parse node file contents
     if exclude_current_node:
         host = get_my_host()

--- a/fireworks/features/multi_launcher.py
+++ b/fireworks/features/multi_launcher.py
@@ -200,7 +200,6 @@ def split_node_lists(num_jobs, total_node_list=None, ppn=24, gpus_per_node=None)
     Returns:
         (([int],[int])) the node list and processor list for each job
     """
-    gpu_lists = None
     if total_node_list:
         orig_node_list = sorted(list(set(total_node_list)))
         nnodes = len(orig_node_list)
@@ -212,11 +211,15 @@ def split_node_lists(num_jobs, total_node_list=None, ppn=24, gpus_per_node=None)
 
         if gpus_per_node is not None:
             gpu_lists = list(range(gpus_per_node)) * nnodes
+        else:
+            gpu_lists = [None] * nnodes
     else:
         sub_nproc_list = [ppn] * num_jobs
         node_lists = [None] * num_jobs
         if gpus_per_node is not None:
             gpu_lists = list(range(gpus_per_node))
+        else:
+            gpu_lists = [None] * num_jobs
     return node_lists, sub_nproc_list, gpu_lists
 
 

--- a/fireworks/features/multi_launcher.py
+++ b/fireworks/features/multi_launcher.py
@@ -78,7 +78,7 @@ def rapidfire_process(
         # If the sub job is using GPU, set the CUDA_VISIBLE_DEVICES environment variable
         # This will limit the GPU usage to only the specified GPU
         os.environ['CUDA_VISIBLE_DEVICES'] = str(gpu_id)
-    print('CUDA_VISIBLE_DEVICES', os.environ.get('CUDA_VISIBLE_DEVICES', None))
+
     ds = DataServer(address=("127.0.0.1", port), authkey=DS_PASSWORD)
     ds.connect()
     launchpad = ds.LaunchPad()

--- a/fireworks/scripts/rlaunch_run.py
+++ b/fireworks/scripts/rlaunch_run.py
@@ -104,6 +104,7 @@ def rlaunch(argv: Optional[Sequence[str]] = None) -> int:
     multi_parser.add_argument(
         "--local_redirect", help="Redirect stdout and stderr to the launch directory", action="store_true"
     )
+    multi_parser.add_argument("--use_gpu", help="Whether or not the job uses GPU compute", default=False, type=bool)
 
     parser.add_argument("-l", "--launchpad_file", help="path to launchpad file")
     parser.add_argument("-w", "--fworker_file", help="path to fworker file")

--- a/fireworks/scripts/rlaunch_run.py
+++ b/fireworks/scripts/rlaunch_run.py
@@ -188,6 +188,7 @@ def rlaunch(argv: Optional[Sequence[str]] = None) -> int:
             timeout=args.timeout,
             exclude_current_node=args.exclude_current_node,
             local_redirect=args.local_redirect,
+            use_gpu=args.use_gpu
         )
     else:
         launch_rocket(launchpad, fworker, args.fw_id, args.loglvl, pdb_on_exception=args.pdb)


### PR DESCRIPTION
There is currently no way to distribute GPUs among fireworks when running small jobs in parallel on one system.

An example: On NERSC, you get exclusive access to 1 Perlmutter nodes with 4 A100 GPUs. If you were to run 4 fireworks that require 1 GPU each, using `rlaunch multi 4`, each firework would be responsible for determining which GPUs to run on. Most python code will default to checking the CUDA_VISIBLE_DEVICES and either taking the first or all gpus resulting in an oversubscription leading to poor performance or an error.

I don't believe this implementation would work for systems with non-NVIDIA/CUDA GPUs. I believe AMD devices require setting the `HIP_VISIBLE_DEVICES` variable, but I don't have access to any system with multiple AMD GPUs to test that.

This might not be the best way to implement this, but it does raise a question about whether or not there is a need for a more general way to distribute non-CPU devices (GPU and TPU) among sub-jobs. 