### PR TITLE
add pbs filesystems option for alcf polaris

### DIFF
--- a/fireworks/user_objects/queue_adapters/PBS_template.txt
+++ b/fireworks/user_objects/queue_adapters/PBS_template.txt
@@ -12,6 +12,7 @@
 #PBS -V $${env}
 #PBS -M $${email} -m $${notification_options}
 #PBS -l pmem=$${pmem}
+#PBS -l filesystems=$${filesystems}
 
 $${pre_rocket}
 cd $${launch_dir}


### PR DESCRIPTION
Dear FireWorks developers,

In testing FireWorks on ALCF Polaris I found that they require the PBS filesystems flag. I have tested it in my own local adapter and now am adding it to your PBS template.

Please let me know if you have any questions. 

Thank you,
Laurie