### PR TITLE
Enable launchpad and fireworker config be passed via json string

### DIFF
--- a/fireworks/scripts/rlaunch_run.py
+++ b/fireworks/scripts/rlaunch_run.py
@@ -117,6 +117,8 @@ def rlaunch(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("--loglvl", help="level to print log messages", default="INFO")
     parser.add_argument("-s", "--silencer", help="shortcut to mute log messages", action="store_true")
 
+    parser.add_argument("--json", help="Pass launchpad and worker files as json-formatted string", action="store_true")
+
     try:
         import argcomplete
 
@@ -136,17 +138,25 @@ def rlaunch(argv: Optional[Sequence[str]] = None) -> int:
         ("launchpad", "-l", False, LAUNCHPAD_LOC),
         ("fworker", "-w", False, FWORKER_LOC),
     ]
-    _validate_config_file_paths(args, cfg_files_to_check)
+    if not args.json:
+        _validate_config_file_paths(args, cfg_files_to_check)
 
     args.loglvl = "CRITICAL" if args.silencer else args.loglvl
+
+    if args.json:
+        launchpad_generator = lambda x: LaunchPad.from_format(x, f_format="json")
+        fworker_generator   = lambda x: FWorker.from_format(x, f_format="json")
+    else:
+        launchpad_generator = lambda x: LaunchPad.form_file(x)
+        fworker_generator   = lambda x: FWorker.from_file(x)
 
     if args.command == "singleshot" and args.offline:
         launchpad = None
     else:
-        launchpad = LaunchPad.from_file(args.launchpad_file) if args.launchpad_file else LaunchPad(strm_lvl=args.loglvl)
+        launchpad = launchpad_generator(args.launchpad_file) if args.launchpad_file else LaunchPad(strm_lvl=args.loglvl)
 
     if args.fworker_file:
-        fworker = FWorker.from_file(args.fworker_file)
+        fworker = fworker_generator(args.fworker_file)
     else:
         fworker = FWorker()
 


### PR DESCRIPTION
This is a relatively simple addition to the `rlaunch` CLI tool: When `--json` is provided, then the inputs to `-l` and `-w` are JSON-formatted strings. This is mainly to allow for `LaunchPad` and `FWorker` to be specified in a python script, without having to generate these files first.

An example workflow can be found here: https://github.com/JBlaschke/alcc-recipes/blob/jpb/fireworks/fireworks/test_3_python/fw.py#L26 where a python script manages a 2-node and a 4-node slurm job. In this case `fireworker_1`, and `fireworker_2` need to be passed to the slurm script in addition to `launchpad`. With the addition of a `--json` flag, this can be handled from the command line without needing to manage additional files.

Tagging @lastephey and @computron  