### PR TITLE
Added a MultiStore to DataServer

### DIFF
--- a/fireworks/features/multi_launcher.py
+++ b/fireworks/features/multi_launcher.py
@@ -20,6 +20,7 @@ from fireworks.utilities.fw_utilities import (
     get_my_host,
     log_multi,
 )
+from maggma.stores.shared_stores import MultiStore
 
 __author__ = "Xiaohui Qu, Anubhav Jain"
 __copyright__ = "Copyright 2013, The Material Project & The Electrolyte Genome Project"
@@ -64,7 +65,7 @@ def rapidfire_process(
         nlaunches (int): 0 means 'until completion', -1 or "infinite" means to loop forever
         sleep (int): secs to sleep between rapidfire loop iterations
         loglvl (str): level at which to output logs to stdout
-        port (int): Listening port number of the shared object manage
+        port (int): Listening port number of the shared object manager
         password (str): security password to access the server
         node_list ([str]): computer node list
         sub_nproc (int): number of processors of the sub job
@@ -247,8 +248,12 @@ def launch_multiprocess(
     node_lists, sub_nproc_list = split_node_lists(num_jobs, total_node_list, ppn)
 
     # create shared dataserver
-    ds = DataServer.setup(launchpad)
+    multistore = MultiStore()
+    ds = DataServer.setup(launchpad, multistore)
     port = ds.address[1]
+
+    # set an environment variable, so that jobs may look for this server
+    os.environ["FW_DATASERVER_PORT"] = str(port) 
 
     manager = Manager()
     running_ids_dict = manager.dict()

--- a/fireworks/utilities/fw_utilities.py
+++ b/fireworks/utilities/fw_utilities.py
@@ -198,15 +198,17 @@ class DataServer(BaseManager):
     """
 
     @classmethod
-    def setup(cls, launchpad):
+    def setup(cls, launchpad, multistore):
         """
         Args:
             launchpad (LaunchPad)
+            multistore (MultiStore)
 
         Returns:
             DataServer
         """
         DataServer.register("LaunchPad", callable=lambda: launchpad)
+        DataServer.register("MultiStore", callable=lambda: multistore)
         m = DataServer(address=("127.0.0.1", 0), authkey=DS_PASSWORD)  # random port
         m.start()
         return m


### PR DESCRIPTION
When running large numbers of calculations simultaneously, `rlaunch multi` takes care to only create one MongoClient instance and take advantage of connection pooling to prevent large numbers of concurrent connections to the mongodb.

However, when a user would like data to be saved to another database or collection, it is typically achieved by creating maggma Stores within a `Firetask` and inserting the document (for example jobflow's [JobFiretask](https://github.com/materialsproject/jobflow/blob/fb522a24cb695dc4cc20c72ae7e1ac77fc5ea7cf/src/jobflow/managers/fireworks.py#L127)). This results in poor control over the number of connections made to a database and the potential for an unlimited number of connections.

To solve this, I have implemented a class which keeps track of the Stores in use and allows individual fireworks to share these Stores. This extends the `DataServer` used to share a `LaunchPad`, by registering an additional callable `MultiStore`. No other fireworks code utilizes this functionality, but it is required that the main process keeps track of it and therefore it cannot be put in another code.

Because I have put this class in maggma, this does require fireworks to have maggma as a dependency. I could also put this class in jobflow, but jobflow (and implicitly maggma) would need to be dependencies.

These are the pull requests for [maggma]() and [jobflow]()