### PR TITLE
[BUG FIX] remove `_id` from `archived_launches`

### DIFF
--- a/fireworks/flask_site/app.py
+++ b/fireworks/flask_site/app.py
@@ -161,7 +161,7 @@ def get_fw_details(fw_id):
     # to control their display
     fw = app.lp.get_fw_dict_by_id(fw_id)
     for launch in fw["launches"]:
-        del launch["_id"]
+        launch.pop("_id", None)
     for launch in fw["archived_launches"]:
         del launch["_id"]
     del fw["_id"]

--- a/fireworks/flask_site/app.py
+++ b/fireworks/flask_site/app.py
@@ -162,6 +162,8 @@ def get_fw_details(fw_id):
     fw = app.lp.get_fw_dict_by_id(fw_id)
     for launch in fw["launches"]:
         del launch["_id"]
+    for launch in fw["archived_launches"]:
+        del launch["_id"]
     del fw["_id"]
     return jsonify(fw)
 


### PR DESCRIPTION
I noticed some restarted jobs not rendering because the `_id` fields are pulled from the `archived_launches` which results in the following error in the `webgui`:

```
  File "/Users/shen9/local/Caskroom/miniconda/base/envs/mp/lib/python3.9/site-packages/flask/json/provider.py", line 122, in _default
    raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
```

And does not allow the page to be opened. This PR should fix that problem.