### PR TITLE
Fix `webgui` KeyError

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--line-length, '120']
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
 

--- a/fireworks/flask_site/util.py
+++ b/fireworks/flask_site/util.py
@@ -22,8 +22,8 @@ def jsonify(*args, **kwargs):
     """
     indent = None
     separators = (",", ":")
-
-    if current_app.config["JSONIFY_PRETTYPRINT_REGULAR"] or current_app.debug:
+    # import ipdb; ipdb.set_trace()
+    if current_app.config.get("JSONIFY_PRETTYPRINT_REGULAR", None) or current_app.debug:
         indent = 2
         separators = (", ", ": ")
 
@@ -36,5 +36,5 @@ def jsonify(*args, **kwargs):
 
     return current_app.response_class(
         dumps(data, indent=indent, separators=separators, cls=MongoJsonEncoder) + "\n",
-        mimetype=current_app.config["JSONIFY_MIMETYPE"],
+        mimetype=current_app.config.get("JSONIFY_MIMETYPE", None),
     )


### PR DESCRIPTION
# Two minor bug fixes

- The WebGUI crashes when some configuration variables cannot be access,  the `.get(..., None)` pattern fixes this and the workflows render for me.
- The `isort` version in the current pre-commit crashes but bumping it to `5.11.5` fixes this.  