### PR TITLE
fix encoding bugs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
         name="FireWorks",
         version="2.0.3",
         description="FireWorks workflow software",
-        long_description=open("README.md", encoding='utf-8').read(),  # noqa: SIM115
+        long_description=open("README.md", encoding="utf-8").read(),  # noqa: SIM115
         url="https://github.com/materialsproject/fireworks",
         author="Anubhav Jain",
         author_email="anubhavster@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
         name="FireWorks",
         version="2.0.3",
         description="FireWorks workflow software",
-        long_description=open("README.md").read(),  # noqa: SIM115
+        long_description=open("README.md", encoding='utf-8').read(),  # noqa: SIM115
         url="https://github.com/materialsproject/fireworks",
         author="Anubhav Jain",
         author_email="anubhavster@gmail.com",


### PR DESCRIPTION
### fix encoding bugs in setup.py
In Windows 10, a bug occurs when installing software via pip install. The reason is that the encoding method was not specified when reading the Readme file in the setup. Therefore, this modification was made.

### Info
python verision: 3.10
numpy version: 1.25.2


### bugs
```
Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [17 lines of output]
      Traceback (most recent call last):
        File "<string>", line 15, in <module>
      UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 815: illegal multibyte sequence
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```