### PR TITLE
Add `<action>_wfs` aliases for all `lpad <action>_wflows` commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,14 @@ exclude: ^docs
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.284
+    rev: v0.1.3
     hooks:
       - id: ruff
         args: [--fix, --ignore, D]
-
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-case-conflict
       - id: check-symlinks

--- a/docs_rst/conf.py
+++ b/docs_rst/conf.py
@@ -12,11 +12,7 @@
 
 import os
 import sys
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
+from importlib import metadata
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/fireworks/core/tests/test_firework.py
+++ b/fireworks/core/tests/test_firework.py
@@ -35,7 +35,8 @@ class FiretaskBaseTest(unittest.TestCase):
             pass
 
         d = DummyTask2()
-        self.assertRaises(NotImplementedError, d.run_task, {})
+        with pytest.raises(NotImplementedError):
+            d.run_task({})
 
     def test_param_checks(self):
         class DummyTask(FiretaskBase):
@@ -43,8 +44,10 @@ class FiretaskBaseTest(unittest.TestCase):
             required_params = ["param1"]
             optional_params = ["param2"]
 
-        self.assertRaises(RuntimeError, DummyTask, param2=3)  # missing required param
-        self.assertRaises(RuntimeError, DummyTask, param1=3, param3=5)  # extraneous param
+        with pytest.raises(RuntimeError):
+            DummyTask(param2=3)  # missing required param
+        with pytest.raises(RuntimeError):
+            DummyTask(param1=3, param3=5)  # extraneous param
         DummyTask(param1=1)  # OK
         DummyTask(param1=1, param2=1)  # OK
 
@@ -102,8 +105,10 @@ class WorkflowTest(unittest.TestCase):
             fws.append(fw)
         wf = Workflow(fws, links_dict={0: [1, 2, 3], 1: [4], 2: [4]})
         assert isinstance(wf, Workflow)
-        self.assertRaises(ValueError, Workflow, fws, links_dict={0: [1, 2, 3], 1: [4], 100: [4]})
-        self.assertRaises(ValueError, Workflow, fws, links_dict={0: [1, 2, 3], 1: [4], 2: [100]})
+        with pytest.raises(ValueError):
+            Workflow(fws, links_dict={0: [1, 2, 3], 1: [4], 100: [4]})
+        with pytest.raises(ValueError):
+            Workflow(fws, links_dict={0: [1, 2, 3], 1: [4], 2: [100]})
 
     def test_copy(self):
         """Test that we can produce a copy of a Workflow but that the copy

--- a/fireworks/core/tests/test_firework.py
+++ b/fireworks/core/tests/test_firework.py
@@ -9,6 +9,8 @@ __date__ = "2/26/14"
 
 import unittest
 
+import pytest
+
 from fireworks.core.firework import FiretaskBase, Firework, FWAction, Workflow
 from fireworks.user_objects.firetasks.script_task import PyTask
 from fireworks.utilities.fw_utilities import explicit_serialize
@@ -22,7 +24,7 @@ class FiretaskBaseTest(unittest.TestCase):
             def run_task(self, fw_spec):
                 return self["hello"]
 
-        with self.assertRaises(RuntimeError):
+        with pytest.raises(RuntimeError):
             DummyTask()
         d = DummyTask(hello="world")
         assert d.run_task({}) == "world"

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -32,7 +32,7 @@ from fireworks.core.tests.tasks import (
 from fireworks.queue.queue_launcher import setup_offline_job
 from fireworks.user_objects.firetasks.script_task import PyTask, ScriptTask
 
-TESTDB_NAME = "fireworks_unittest"
+TEST_DB_NAME = "fireworks_unittest"
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 PYMONGO_MAJOR_VERSION = int(PYMONGO_VERSION[0])
 
@@ -75,7 +75,7 @@ class LaunchPadTest(unittest.TestCase):
         cls.lp = None
         cls.fworker = FWorker()
         try:
-            cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl="ERROR")
+            cls.lp = LaunchPad(name=TEST_DB_NAME, strm_lvl="ERROR")
             cls.lp.reset(password=None, require_password=False)
         except Exception:
             raise unittest.SkipTest("MongoDB is not running in localhost:27017! Skipping tests.")
@@ -83,7 +83,7 @@ class LaunchPadTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         if cls.lp:
-            cls.lp.connection.drop_database(TESTDB_NAME)
+            cls.lp.connection.drop_database(TEST_DB_NAME)
         cls.lp.connection
 
     def setUp(self):
@@ -135,7 +135,7 @@ class LaunchPadTest(unittest.TestCase):
         self.lp.add_wf(fw)
         args = ("",)
         with pytest.raises(ValueError):
-            self.lp.add_wf(args)
+            self.lp.add_wf(*args)
 
     def test_add_wf(self):
         fw = Firework(ScriptTask.from_str('echo "hello"'), name="hello")
@@ -176,7 +176,7 @@ class LaunchPadDefuseReigniteRerunArchiveDeleteTest(unittest.TestCase):
         cls.lp = None
         cls.fworker = FWorker()
         try:
-            cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl="ERROR")
+            cls.lp = LaunchPad(name=TEST_DB_NAME, strm_lvl="ERROR")
             cls.lp.reset(password=None, require_password=False)
         except Exception:
             raise unittest.SkipTest("MongoDB is not running in localhost:27017! Skipping tests.")
@@ -184,7 +184,7 @@ class LaunchPadDefuseReigniteRerunArchiveDeleteTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         if cls.lp:
-            cls.lp.connection.drop_database(TESTDB_NAME)
+            cls.lp.connection.drop_database(TEST_DB_NAME)
 
     def setUp(self):
         # define the individual FireWorks used in the Workflow
@@ -565,7 +565,7 @@ class LaunchPadLostRunsDetectTest(unittest.TestCase):
         cls.lp = None
         cls.fworker = FWorker()
         try:
-            cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl="ERROR")
+            cls.lp = LaunchPad(name=TEST_DB_NAME, strm_lvl="ERROR")
             cls.lp.reset(password=None, require_password=False)
         except Exception:
             raise unittest.SkipTest("MongoDB is not running in localhost:27017! Skipping tests.")
@@ -573,7 +573,7 @@ class LaunchPadLostRunsDetectTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         if cls.lp:
-            cls.lp.connection.drop_database(TESTDB_NAME)
+            cls.lp.connection.drop_database(TEST_DB_NAME)
 
     def setUp(self):
         # Define a timed fireWork
@@ -707,7 +707,7 @@ class WorkflowFireworkStatesTest(unittest.TestCase):
         cls.lp = None
         cls.fworker = FWorker()
         try:
-            cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl="ERROR")
+            cls.lp = LaunchPad(name=TEST_DB_NAME, strm_lvl="ERROR")
             cls.lp.reset(password=None, require_password=False)
         except Exception:
             raise unittest.SkipTest("MongoDB is not running in localhost:27017! Skipping tests.")
@@ -715,7 +715,7 @@ class WorkflowFireworkStatesTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         if cls.lp:
-            cls.lp.connection.drop_database(TESTDB_NAME)
+            cls.lp.connection.drop_database(TEST_DB_NAME)
 
     def setUp(self):
         # define the individual FireWorks used in the Workflow
@@ -1017,7 +1017,7 @@ class LaunchPadRerunExceptionTest(unittest.TestCase):
         cls.lp = None
         cls.fworker = FWorker()
         try:
-            cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl="ERROR")
+            cls.lp = LaunchPad(name=TEST_DB_NAME, strm_lvl="ERROR")
             cls.lp.reset(password=None, require_password=False)
         except Exception:
             raise unittest.SkipTest("MongoDB is not running in localhost:27017! Skipping tests.")
@@ -1025,7 +1025,7 @@ class LaunchPadRerunExceptionTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         if cls.lp:
-            cls.lp.connection.drop_database(TESTDB_NAME)
+            cls.lp.connection.drop_database(TEST_DB_NAME)
 
     def setUp(self):
         fireworks.core.firework.EXCEPT_DETAILS_ON_RERUN = True
@@ -1110,7 +1110,7 @@ class WFLockTest(unittest.TestCase):
         cls.lp = None
         cls.fworker = FWorker()
         try:
-            cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl="ERROR")
+            cls.lp = LaunchPad(name=TEST_DB_NAME, strm_lvl="ERROR")
             cls.lp.reset(password=None, require_password=False)
         except Exception:
             raise unittest.SkipTest("MongoDB is not running in localhost:27017! Skipping tests.")
@@ -1118,7 +1118,7 @@ class WFLockTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         if cls.lp:
-            cls.lp.connection.drop_database(TESTDB_NAME)
+            cls.lp.connection.drop_database(TEST_DB_NAME)
 
     def setUp(self):
         # set the defaults in the init of wflock to break the lock quickly
@@ -1241,7 +1241,7 @@ class LaunchPadOfflineTest(unittest.TestCase):
         cls.lp = None
         cls.fworker = FWorker()
         try:
-            cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl="ERROR")
+            cls.lp = LaunchPad(name=TEST_DB_NAME, strm_lvl="ERROR")
             cls.lp.reset(password=None, require_password=False)
         except Exception:
             raise unittest.SkipTest("MongoDB is not running in localhost:27017! Skipping tests.")
@@ -1249,7 +1249,7 @@ class LaunchPadOfflineTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         if cls.lp:
-            cls.lp.connection.drop_database(TESTDB_NAME)
+            cls.lp.connection.drop_database(TEST_DB_NAME)
 
     def setUp(self):
         fireworks.core.firework.EXCEPT_DETAILS_ON_RERUN = True
@@ -1322,7 +1322,7 @@ class GridfsStoredDataTest(unittest.TestCase):
         cls.lp = None
         cls.fworker = FWorker()
         try:
-            cls.lp = LaunchPad(name=TESTDB_NAME, strm_lvl="ERROR")
+            cls.lp = LaunchPad(name=TEST_DB_NAME, strm_lvl="ERROR")
             cls.lp.reset(password=None, require_password=False)
         except Exception:
             raise unittest.SkipTest("MongoDB is not running in localhost:27017! Skipping tests.")
@@ -1330,7 +1330,7 @@ class GridfsStoredDataTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         if cls.lp:
-            cls.lp.connection.drop_database(TESTDB_NAME)
+            cls.lp.connection.drop_database(TEST_DB_NAME)
 
     def setUp(self):
         self.old_wd = os.getcwd()

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -13,6 +13,7 @@ import time
 import unittest
 from multiprocessing import Process
 
+import pytest
 from monty.os import cd
 from pymongo import MongoClient
 from pymongo import __version__ as PYMONGO_VERSION
@@ -49,7 +50,7 @@ class AuthenticationTest(unittest.TestCase):
 
     def test_no_admin_privileges_for_plebs(self):
         """Normal users can not authenticate against the admin db."""
-        with self.assertRaises(OperationFailure):
+        with pytest.raises(OperationFailure):
             lp = LaunchPad(name="admin", username="myuser", password="mypassword", authsource="admin")
             lp.db.collection.count_documents({})
 
@@ -484,7 +485,7 @@ class LaunchPadDefuseReigniteRerunArchiveDeleteTest(unittest.TestCase):
         # Delete workflow containing Zeus.
         self.lp.delete_wf(self.zeus_fw_id)
         # Check if any fireworks and the workflow are available
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.lp.get_wf_by_fw_id(self.zeus_fw_id)
         fw_ids = self.lp.get_fw_ids()
         assert not fw_ids
@@ -506,7 +507,7 @@ class LaunchPadDefuseReigniteRerunArchiveDeleteTest(unittest.TestCase):
         # Delete workflow containing Zeus.
         self.lp.delete_wf(self.zeus_fw_id, delete_launch_dirs=True)
         # Check if any fireworks and the workflow are available
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.lp.get_wf_by_fw_id(self.zeus_fw_id)
         fw_ids = self.lp.get_fw_ids()
         assert not fw_ids

--- a/fireworks/core/tests/test_launchpad.py
+++ b/fireworks/core/tests/test_launchpad.py
@@ -115,7 +115,8 @@ class LaunchPadTest(unittest.TestCase):
         fw = Firework(ScriptTask.from_str('echo "hello"'), name="hello")
         wf = Workflow([fw], name="test_workflow")
         self.lp.add_wf(wf)
-        self.assertRaises(ValueError, self.lp.reset, "", False, 0)
+        with pytest.raises(ValueError):
+            self.lp.reset("", require_password=False, max_reset_wo_password=0)
         assert self.lp.workflows.count_documents({}) == 1
         self.lp.reset("", require_password=False)
         assert not self.lp.get_fw_ids()
@@ -125,14 +126,16 @@ class LaunchPadTest(unittest.TestCase):
         for _ in range(30):
             self.lp.add_wf(Workflow([Firework(ScriptTask.from_str('echo "hello"'))]))
 
-        self.assertRaises(ValueError, self.lp.reset, "")
+        with pytest.raises(ValueError):
+            self.lp.reset("")
         self.lp.reset("", False, 100)  # reset back
 
     def test_pw_check(self):
         fw = Firework(ScriptTask.from_str('echo "hello"'), name="hello")
         self.lp.add_wf(fw)
         args = ("",)
-        self.assertRaises(ValueError, self.lp.reset, *args)
+        with pytest.raises(ValueError):
+            self.lp.add_wf(args)
 
     def test_add_wf(self):
         fw = Firework(ScriptTask.from_str('echo "hello"'), name="hello")

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -1062,7 +1062,9 @@ def lpad(argv: Optional[Sequence[str]] = None) -> int:
     get_fw_parser.set_defaults(func=get_fws)
 
     get_fw_in_wf_parser = subparsers.add_parser(
-        "get_fws_in_wflows", help="get information about FireWorks in Workflows"
+        "get_fws_in_wflows",
+        help="get information about FireWorks in Workflows",
+        aliases=["get_fws_in_wfs"],
     )
 
     get_fw_in_wf_parser.add_argument(*wf_prefixed_fw_id_args, **fw_id_kwargs)
@@ -1204,7 +1206,11 @@ def lpad(argv: Optional[Sequence[str]] = None) -> int:
     )
     update_fws_parser.set_defaults(func=update_fws)
 
-    get_wf_parser = subparsers.add_parser("get_wflows", help="get information about Workflows")
+    get_wf_parser = subparsers.add_parser(
+        "get_wflows",
+        help="get information about Workflows",
+        aliases=["get_wfs"],
+    )
     get_wf_parser.add_argument(*fw_id_args, **fw_id_kwargs)
     get_wf_parser.add_argument("-n", "--name", help="get WFs with this name")
     get_wf_parser.add_argument(*state_args, **state_kwargs)
@@ -1236,7 +1242,11 @@ def lpad(argv: Optional[Sequence[str]] = None) -> int:
     )
     defuse_wf_parser.set_defaults(func=pause_wfs)
 
-    pause_wf_parser = subparsers.add_parser("pause_wflows", help="pause an entire Workflow")
+    pause_wf_parser = subparsers.add_parser(
+        "pause_wflows",
+        help="pause an entire Workflow",
+        aliases=["pause_wfs"],
+    )
     pause_wf_parser.add_argument(*fw_id_args, **fw_id_kwargs)
     pause_wf_parser.add_argument("-n", "--name", help="name")
     pause_wf_parser.add_argument(*state_args, **state_kwargs)
@@ -1248,7 +1258,11 @@ def lpad(argv: Optional[Sequence[str]] = None) -> int:
     )
     pause_wf_parser.set_defaults(func=pause_wfs)
 
-    reignite_wfs_parser = subparsers.add_parser("reignite_wflows", help="reignite (un-cancel) an entire Workflow")
+    reignite_wfs_parser = subparsers.add_parser(
+        "reignite_wflows",
+        help="reignite (un-cancel) an entire Workflow",
+        aliases=["reignite_wfs"],
+    )
     reignite_wfs_parser.add_argument(*fw_id_args, **fw_id_kwargs)
     reignite_wfs_parser.add_argument("-n", "--name", help="name")
     reignite_wfs_parser.add_argument(*state_args, **state_kwargs)
@@ -1260,7 +1274,11 @@ def lpad(argv: Optional[Sequence[str]] = None) -> int:
     )
     reignite_wfs_parser.set_defaults(func=reignite_wfs)
 
-    archive_parser = subparsers.add_parser("archive_wflows", help="archive an entire Workflow (irreversible)")
+    archive_parser = subparsers.add_parser(
+        "archive_wflows",
+        help="archive an entire Workflow (irreversible)",
+        aliases=["archive_wfs"],
+    )
     archive_parser.add_argument(*fw_id_args, **fw_id_kwargs)
     archive_parser.add_argument("-n", "--name", help="name")
     archive_parser.add_argument(*state_args, **state_kwargs)
@@ -1275,6 +1293,7 @@ def lpad(argv: Optional[Sequence[str]] = None) -> int:
     delete_wfs_parser = subparsers.add_parser(
         "delete_wflows",
         help='Delete workflows (permanently). Use "archive_wflows" instead if you want to "soft-remove"',
+        aliases=["delete_wfs"],
     )
     delete_wfs_parser.add_argument(*fw_id_args, **fw_id_kwargs)
     delete_wfs_parser.add_argument("-n", "--name", help="name")

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -6,10 +6,10 @@ import datetime
 import json
 import os
 import re
-import sys
 import time
 from argparse import ArgumentParser, ArgumentTypeError, Namespace
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from importlib import metadata
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union
 
 import ruamel.yaml as yaml
 from pymongo import ASCENDING, DESCENDING
@@ -35,13 +35,6 @@ from fireworks.user_objects.firetasks.script_task import ScriptTask
 from fireworks.utilities.fw_serializers import DATETIME_HANDLER, recursive_dict
 
 from ._helpers import _validate_config_file_paths
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-    from typing_extensions import Literal
-else:
-    from importlib import metadata
-    from typing import Literal
 
 __author__ = "Anubhav Jain"
 __credits__ = "Shyue Ping Ong"

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -193,17 +193,15 @@ def init_yaml(args: Namespace) -> None:
 def reset(args: Namespace) -> None:
     lp = get_lp(args)
     if not args.password:
-        if (
-                input(
-                    f"Are you sure? This will RESET "
-                    f"{lp.workflows.count_documents({})} workflows and all "
-                    f"data. To confirm, please type the name of this database "
-                    f"({lp.name}) :") == lp.name
-        ):
+        n_docs = lp.workflows.count_documents({})
+        answer = input(
+            f"Are you sure? This will RESET {n_docs} workflows and all data. "
+            f"To confirm, please type the name of this database ({lp.name}) :"
+        )
+        if answer == lp.name:
             args.password = datetime.datetime.now().strftime("%Y-%m-%d")
         else:
-            raise ValueError(
-                "Incorrect input to confirm database reset, operation aborted.")
+            raise ValueError("Incorrect input to confirm database reset, operation aborted.")
     lp.reset(args.password)
 
 

--- a/fireworks/scripts/mlaunch_run.py
+++ b/fireworks/scripts/mlaunch_run.py
@@ -1,8 +1,8 @@
 """A runnable script to launch Job Packing (Multiple) Rockets."""
 
 import os
-import sys
 from argparse import ArgumentParser
+from importlib import metadata
 from typing import Optional, Sequence
 
 from fireworks.core.fworker import FWorker
@@ -11,11 +11,6 @@ from fireworks.features.multi_launcher import launch_multiprocess
 from fireworks.fw_config import CONFIG_FILE_DIR, FWORKER_LOC, LAUNCHPAD_LOC
 
 from ._helpers import _validate_config_file_paths
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
 
 __author__ = "Xiaohui Qu, Anubhav Jain"
 __copyright__ = "Copyright 2013, The Materials Project & Electrolyte Genome Project"

--- a/fireworks/scripts/qlaunch_run.py
+++ b/fireworks/scripts/qlaunch_run.py
@@ -1,6 +1,5 @@
 """A runnable script for launching rockets (a command-line interface to queue_launcher.py)."""
 import os
-import sys
 import time
 from argparse import ArgumentParser
 from typing import Optional, Sequence
@@ -15,6 +14,8 @@ except ImportError:
 else:
     HAS_FABRIC = True
 
+from importlib import metadata
+
 from fireworks.core.fworker import FWorker
 from fireworks.core.launchpad import LaunchPad
 from fireworks.fw_config import CONFIG_FILE_DIR, FWORKER_LOC, LAUNCHPAD_LOC, QUEUEADAPTER_LOC
@@ -22,11 +23,6 @@ from fireworks.queue.queue_launcher import launch_rocket_to_queue, rapidfire
 from fireworks.utilities.fw_serializers import load_object_from_file
 
 from ._helpers import _validate_config_file_paths
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
 
 __authors__ = "Anubhav Jain, Shyue Ping Ong"
 __copyright__ = "Copyright 2013, The Materials Project"

--- a/fireworks/scripts/rlaunch_run.py
+++ b/fireworks/scripts/rlaunch_run.py
@@ -4,6 +4,7 @@ import os
 import signal
 import sys
 from argparse import ArgumentParser
+from importlib import metadata
 from typing import Optional, Sequence
 
 from fireworks.core.fworker import FWorker
@@ -14,11 +15,6 @@ from fireworks.fw_config import CONFIG_FILE_DIR, FWORKER_LOC, LAUNCHPAD_LOC
 from fireworks.utilities.fw_utilities import get_fw_logger, get_my_host, get_my_ip
 
 from ._helpers import _validate_config_file_paths
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
 
 __author__ = "Anubhav Jain"
 __credits__ = "Xiaohui Qu, Shyam Dwaraknath"

--- a/fireworks/tests/master_tests.py
+++ b/fireworks/tests/master_tests.py
@@ -5,6 +5,8 @@ completed properly.
 
 import unittest
 
+import pytest
+
 from fireworks import Firework, FWAction
 from fireworks.core.firework import Workflow
 from fireworks.user_objects.firetasks.script_task import ScriptTask
@@ -52,7 +54,8 @@ class BasicTests(unittest.TestCase):
             fw2.fw_id: [fw3.fw_id],
             fw3.fw_id: [],
         }
-        self.assertRaises(ValueError, Workflow, [fw1, fw3])  # can't make this
+        with pytest.raises(ValueError):
+            Workflow([fw1, fw3])  # can't make this
 
 
 class SerializationTests(unittest.TestCase):

--- a/fireworks/tests/mongo_tests.py
+++ b/fireworks/tests/mongo_tests.py
@@ -7,6 +7,8 @@ import time
 import unittest
 from multiprocessing import Pool
 
+import pytest
+
 from fireworks import FWAction, explicit_serialize
 from fireworks.core.firework import FiretaskBase, Firework, Workflow
 from fireworks.core.fworker import FWorker
@@ -472,8 +474,10 @@ class MongoTests(unittest.TestCase):
         launch_rocket(self.lp, self.fworker)
         assert self.lp.get_launch_by_id(1).action.stored_data["stdout"] == "test1\n"
         self.lp.delete_wf(fw.fw_id)
-        self.assertRaises(ValueError, self.lp.get_fw_by_id, fw.fw_id)
-        self.assertRaises(ValueError, self.lp.get_launch_by_id, 1)
+        with pytest.raises(ValueError):
+            self.lp.get_fw_by_id(fw.fw_id)
+        with pytest.raises(ValueError):
+            self.lp.get_launch_by_id(1)
 
     def test_duplicate_delete_fw(self):
         test1 = ScriptTask.from_str("python -c 'print(\"test1\")'", {"store_stdout": True})
@@ -488,7 +492,8 @@ class MongoTests(unittest.TestCase):
         run_id = self.lp.get_launch_by_id(1).fw_id
         del_id = 1 if run_id == 2 else 2
         self.lp.delete_wf(del_id)
-        self.assertRaises(ValueError, self.lp.get_fw_by_id, del_id)
+        with pytest.raises(ValueError):
+            self.lp.get_fw_by_id(del_id)
         assert self.lp.get_launch_by_id(1).action.stored_data["stdout"] == "test1\n"
 
     def test_dupefinder(self):
@@ -540,7 +545,8 @@ class MongoTests(unittest.TestCase):
         assert new_fw.spec["dummy2"] == [True]
 
         new_wf = Workflow([Firework([ModSpecTask()])])
-        self.assertRaises(ValueError, self.lp.append_wf, new_wf, [4], detour=True)
+        with pytest.raises(ValueError):
+            self.lp.append_wf(new_wf, [4], detour=True)
 
     def test_append_wf_detour(self):
         fw1 = Firework([ModSpecTask()], fw_id=1)

--- a/fireworks/user_objects/firetasks/tests/test_fileio_tasks.py
+++ b/fireworks/user_objects/firetasks/tests/test_fileio_tasks.py
@@ -7,6 +7,8 @@ __date__ = "1/6/14"
 import os
 import unittest
 
+import pytest
+
 from fireworks.user_objects.firetasks.fileio_tasks import (
     ArchiveDirTask,
     CompressDirTask,
@@ -22,7 +24,8 @@ class FileWriteDeleteTest(unittest.TestCase):
     def test_init(self):
         FileWriteTask(files_to_write="hello")
         FileWriteTask({"files_to_write": "hello"})
-        self.assertRaises(RuntimeError, FileWriteTask)
+        with pytest.raises(RuntimeError):
+            FileWriteTask()
 
     def test_run(self):
         t = load_object_from_file(os.path.join(module_dir, "write.yaml"))

--- a/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
+++ b/fireworks/user_objects/firetasks/tests/test_filepad_tasks.py
@@ -3,6 +3,7 @@ __author__ = "Kiran Mathew, Johannes Hoermann"
 import os
 import unittest
 
+import pytest
 from ruamel.yaml import YAML
 
 from fireworks.user_objects.firetasks.filepad_tasks import (
@@ -133,7 +134,7 @@ class FilePadTasksTest(unittest.TestCase):
             dest_dir=dest_dir,
             new_file_names=["queried_test_file.txt"],
         )
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             t.run_task({})
         # test successful if exception raised
 
@@ -174,7 +175,7 @@ class FilePadTasksTest(unittest.TestCase):
         os.remove("degenerate_file.txt")
 
         t = GetFilesByQueryTask(query={"metadata->key": "value"}, fizzle_degenerate_file_name=True)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             t.run_task({})
         # test successful if exception raised
 

--- a/fireworks/utilities/tests/test_dagflow.py
+++ b/fireworks/utilities/tests/test_dagflow.py
@@ -8,6 +8,8 @@ import os
 import unittest
 import uuid
 
+import pytest
+
 from fireworks import Firework, PyTask, Workflow
 
 
@@ -46,7 +48,7 @@ class DAGFlowTest(unittest.TestCase):
 
         wfl = Workflow([self.fw1, self.fw2, self.fw3], {self.fw1: self.fw2, self.fw2: self.fw3, self.fw3: self.fw1})
         msg = "The workflow graph must be a DAG.: found cycles:"
-        with self.assertRaises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             DAGFlow.from_fireworks(wfl).check()
         assert msg in str(context.exception)
 
@@ -56,7 +58,7 @@ class DAGFlowTest(unittest.TestCase):
 
         wfl = Workflow([self.fw1, self.fw2, self.fw3], {self.fw1: self.fw2})
         msg = "The workflow graph must be connected"
-        with self.assertRaises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             DAGFlow.from_fireworks(wfl).check()
         assert msg in str(context.exception)
 
@@ -66,7 +68,7 @@ class DAGFlowTest(unittest.TestCase):
 
         wfl = Workflow([self.fw1, self.fw2, self.fw3], {self.fw1: [self.fw2, self.fw3]})
         msg = "Every input in inputs list must have exactly one source."
-        with self.assertRaises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             DAGFlow.from_fireworks(wfl).check()
         assert msg in str(context.exception)
 
@@ -83,7 +85,7 @@ class DAGFlowTest(unittest.TestCase):
             r"Every input in inputs list must have exactly one source.', 'step', "
             r"'pow(pow(2, 3), 4)', 'entity', 'exponent', 'sources', []"
         )
-        with self.assertRaises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             DAGFlow.from_fireworks(wfl).check()
         assert msg in str(context.exception)
 
@@ -101,7 +103,7 @@ class DAGFlowTest(unittest.TestCase):
             r"'Every input in inputs list must have exactly one source.', 'step', "
             r"'pow(pow(2, 3), 4)', 'entity', 'first power', 'sources'"
         )
-        with self.assertRaises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             DAGFlow.from_fireworks(wfl).check()
         assert msg in str(context.exception)
 
@@ -117,7 +119,7 @@ class DAGFlowTest(unittest.TestCase):
             r"'Every input in inputs list must have exactly one source.', 'step', "
             r"'the third one', 'entity', 'second power', 'sources', [0, 1]"
         )
-        with self.assertRaises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             DAGFlow.from_fireworks(wfl).check()
         assert msg in str(context.exception)
 
@@ -131,7 +133,7 @@ class DAGFlowTest(unittest.TestCase):
         ]
         fwk = Firework(tasks, spec={"exponent": 4, "first power 1": 8, "first power 2": 4})
         msg = "Several tasks may not use the same name in outputs list."
-        with self.assertRaises(AssertionError) as context:
+        with pytest.raises(AssertionError) as context:
             DAGFlow.from_fireworks(Workflow([fwk], {})).check()
         assert msg in str(context.exception)
 

--- a/fireworks/utilities/tests/test_dagflow.py
+++ b/fireworks/utilities/tests/test_dagflow.py
@@ -48,9 +48,9 @@ class DAGFlowTest(unittest.TestCase):
 
         wfl = Workflow([self.fw1, self.fw2, self.fw3], {self.fw1: self.fw2, self.fw2: self.fw3, self.fw3: self.fw1})
         msg = "The workflow graph must be a DAG.: found cycles:"
-        with pytest.raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as exc:
             DAGFlow.from_fireworks(wfl).check()
-        assert msg in str(context.exception)
+        assert msg in str(exc.value)
 
     def test_dagflow_cut(self):
         """Disconnected graph."""
@@ -58,9 +58,9 @@ class DAGFlowTest(unittest.TestCase):
 
         wfl = Workflow([self.fw1, self.fw2, self.fw3], {self.fw1: self.fw2})
         msg = "The workflow graph must be connected"
-        with pytest.raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as exc:
             DAGFlow.from_fireworks(wfl).check()
-        assert msg in str(context.exception)
+        assert msg in str(exc.value)
 
     def test_dagflow_link(self):
         """Wrong links."""
@@ -68,9 +68,9 @@ class DAGFlowTest(unittest.TestCase):
 
         wfl = Workflow([self.fw1, self.fw2, self.fw3], {self.fw1: [self.fw2, self.fw3]})
         msg = "Every input in inputs list must have exactly one source."
-        with pytest.raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as exc:
             DAGFlow.from_fireworks(wfl).check()
-        assert msg in str(context.exception)
+        assert msg in str(exc.value)
 
     def test_dagflow_missing_input(self):
         """Missing input."""
@@ -85,9 +85,9 @@ class DAGFlowTest(unittest.TestCase):
             r"Every input in inputs list must have exactly one source.', 'step', "
             r"'pow(pow(2, 3), 4)', 'entity', 'exponent', 'sources', []"
         )
-        with pytest.raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as exc:
             DAGFlow.from_fireworks(wfl).check()
-        assert msg in str(context.exception)
+        assert msg in str(exc.value)
 
     def test_dagflow_clashing_inputs(self):
         """Parent firework output overwrites an input in spec."""
@@ -103,9 +103,9 @@ class DAGFlowTest(unittest.TestCase):
             r"'Every input in inputs list must have exactly one source.', 'step', "
             r"'pow(pow(2, 3), 4)', 'entity', 'first power', 'sources'"
         )
-        with pytest.raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as exc:
             DAGFlow.from_fireworks(wfl).check()
-        assert msg in str(context.exception)
+        assert msg in str(exc.value)
 
     def test_dagflow_race_condition(self):
         """Two parent firework outputs overwrite each other."""
@@ -119,9 +119,9 @@ class DAGFlowTest(unittest.TestCase):
             r"'Every input in inputs list must have exactly one source.', 'step', "
             r"'the third one', 'entity', 'second power', 'sources', [0, 1]"
         )
-        with pytest.raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as exc:
             DAGFlow.from_fireworks(wfl).check()
-        assert msg in str(context.exception)
+        assert msg in str(exc.value)
 
     def test_dagflow_clashing_outputs(self):
         """Subsequent task overwrites output of a task."""
@@ -133,9 +133,9 @@ class DAGFlowTest(unittest.TestCase):
         ]
         fwk = Firework(tasks, spec={"exponent": 4, "first power 1": 8, "first power 2": 4})
         msg = "Several tasks may not use the same name in outputs list."
-        with pytest.raises(AssertionError) as context:
+        with pytest.raises(AssertionError) as exc:
             DAGFlow.from_fireworks(Workflow([fwk], {})).check()
-        assert msg in str(context.exception)
+        assert msg in str(exc.value)
 
     def test_dagflow_non_dataflow_tasks(self):
         """non-dataflow tasks using outputs and inputs keys do not fail."""

--- a/tasks.py
+++ b/tasks.py
@@ -3,17 +3,12 @@
 
 import json
 import os
-import sys
 import webbrowser
+from importlib import metadata
 
 import requests
 from invoke import task
 from monty.os import cd
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
 
 """
 Deployment file to facilitate releases.


### PR DESCRIPTION
Python code and CLI are currently inconsistent. Python calls functions `get_wflows`, `delete_wfs`, `reignite_wfs`, etc. while CLI calls them `get_wfs`, `delete_wflows`,` `reignite_wflows`, etc.

This PR adds `argparse.subparser(aliases: list[str])` so that both `get_wfs` and `get_wflows` etc. work.