### PR TITLE
Adaptions to ruamel.yaml new API

### DIFF
--- a/fireworks/user_objects/firetasks/dataflow_tasks.py
+++ b/fireworks/user_objects/firetasks/dataflow_tasks.py
@@ -6,6 +6,8 @@ __copyright__ = "Copyright 2016, Karlsruhe Institute of Technology"
 
 import sys
 
+from ruamel.yaml import YAML
+
 from fireworks import Firework
 from fireworks.core.firework import FiretaskBase, FWAction
 from fireworks.utilities.fw_serializers import load_object
@@ -300,7 +302,7 @@ class ForeachTask(FiretaskBase):
         chunklen = lensplit // nchunks
         if lensplit % nchunks > 0:
             chunklen = chunklen + 1
-        chunks = [split_field[i : i + chunklen] for i in range(0, lensplit, chunklen)]
+        chunks = [split_field[i:i+chunklen] for i in range(0, lensplit, chunklen)]
 
         fireworks = []
         for index, chunk in enumerate(chunks):
@@ -381,8 +383,6 @@ class ImportDataTask(FiretaskBase):
         import operator
         from functools import reduce
 
-        import ruamel.yaml as yaml
-
         filename = self["filename"]
         mapstring = self["mapstring"]
         assert isinstance(filename, basestring)
@@ -392,7 +392,7 @@ class ImportDataTask(FiretaskBase):
         fmt = filename.split(".")[-1]
         assert fmt in ["json", "yaml"]
         with open(filename) as inp:
-            data = json.load(inp) if fmt == "json" else yaml.safe_load(inp)
+            data = json.load(inp) if fmt == "json" else YAML(typ="safe", pure=True).load(inp)
 
         leaf = reduce(operator.getitem, maplist[:-1], fw_spec)
         if isinstance(data, dict):

--- a/fireworks/user_objects/firetasks/tests/test_dataflow_tasks.py
+++ b/fireworks/user_objects/firetasks/tests/test_dataflow_tasks.py
@@ -5,6 +5,8 @@ import unittest
 import uuid
 from unittest import SkipTest
 
+from ruamel.yaml import YAML
+
 from fireworks.user_objects.firetasks.dataflow_tasks import (
     CommandLineTask,
     ForeachTask,
@@ -293,11 +295,9 @@ class ImportDataTaskTest(unittest.TestCase):
         """Loads data from a file into spec."""
         import json
 
-        import ruamel.yaml as yaml
-
         temperature = {"value": 273.15, "units": "Kelvin"}
         spec = {"state parameters": {}}
-        formats = {"json": json, "yaml": yaml}
+        formats = {"json": json, "yaml": YAML(typ="safe", pure=True)}
         params = {"mapstring": "state parameters/temperature"}
         for fmt in formats:
             filename = str(uuid.uuid4()) + "." + fmt

--- a/fireworks/user_objects/queue_adapters/tests/test_common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/tests/test_common_adapter.py
@@ -9,6 +9,8 @@ __date__ = "12/31/13"
 
 import unittest
 
+from ruamel.yaml import YAML
+
 from fireworks.user_objects.queue_adapters.common_adapter import CommonAdapter, os
 from fireworks.utilities.fw_serializers import load_object, load_object_from_file
 
@@ -41,9 +43,9 @@ class CommonAdapterTest(unittest.TestCase):
         p = load_object_from_file(os.path.join(os.path.dirname(__file__), "pbs.yaml"))
         p = CommonAdapter(q_type="PBS", q_name="hello", ppnode="8:ib", nnodes=1, hello="world", queue="random")
         print(p.get_script_str("."))
-        import ruamel.yaml as yaml
-
-        print(yaml.safe_dump(p.to_dict(), default_flow_style=False))
+        yaml = YAML(typ="safe", pure=True)
+        yaml.default_flow_style = False
+        print(yaml.dump(p.to_dict()))
 
     def test_parse_njobs(self):
         pbs = """

--- a/fireworks/user_objects/queue_adapters/tests/test_common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/tests/test_common_adapter.py
@@ -7,6 +7,7 @@ __maintainer__ = "Shyue Ping Ong"
 __email__ = "shyuep@gmail.com"
 __date__ = "12/31/13"
 
+import sys
 import unittest
 
 from ruamel.yaml import YAML
@@ -45,7 +46,8 @@ class CommonAdapterTest(unittest.TestCase):
         print(p.get_script_str("."))
         yaml = YAML(typ="safe", pure=True)
         yaml.default_flow_style = False
-        print(yaml.dump(p.to_dict()))
+        yaml.dump(p.to_dict(), sys.stdout)
+        print()
 
     def test_parse_njobs(self):
         pbs = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 120
 
 [tool.ruff]
 target-version = "py38"
-line-length = 180
+line-length = 120
 select = [
   "B",    # flake8-bugbear
   "C4",   # flake8-comprehensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 120
 
 [tool.ruff]
 target-version = "py38"
-line-length = 120
+line-length = 180
 select = [
   "B",    # flake8-bugbear
   "C4",   # flake8-comprehensions


### PR DESCRIPTION
Closes #516 
 
## Summary

Starting from release 0.15, ruamel.yaml has [introduced a new API](https://yaml.readthedocs.io/en/latest/api/). Starting with ruamel.yaml release 0.18 the old interface used in fireworks is depricated and removed. A future deprecation warning is shown with the releases in between. The warning turns into an `AttributeError` with ruamel.yaml >=18.0 (see issue #516 for more details).

Major changes:

- adapted all instances of `yaml.safe_load()` and `yaml.safe_dump()` to the new interface

## Todos

If this is work in progress, what else needs to be done?

- 

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
