### PR TITLE
Logging in rocket.py and launch_rocket.py

### DIFF
--- a/docs_rst/config_tutorial.rst
+++ b/docs_rst/config_tutorial.rst
@@ -76,6 +76,7 @@ A few basic parameters that can be tweaked are:
 * ``WEBSERVER_HOST: 127.0.0.1`` - the default host on which to run the web server
 * ``WEBSERVER_PORT: 5000`` - the default port on which to run the web server
 * ``QUEUE_JOBNAME_MAXLEN: 20`` - the max length of the job name to send to the queuing system (some queuing systems limit the size of job names)
+* ``ROCKET_STREAM_LOGLEVEL: INFO`` - the streaming log level of the rocket launcher logger (valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL)
 
 Parameters that you probably shouldn't change
 ---------------------------------------------

--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -150,7 +150,8 @@ class Rocket:
             launch_id = None  # we don't need this in offline mode...
 
         if not m_fw:
-            print(f"No FireWorks are ready to run and match query! {self.fworker.query}")
+            msg = f"No FireWorks are ready to run and match query! {self.fworker.query}"
+            l_logger.log(logging.INFO, msg)
             return False
 
         final_state = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,10 @@ ignore = [
   "D105",    # Missing docstring in magic method
   "D205",    # 1 blank line required between summary line and description
   "D212",    # Multi-line docstring summary should start at the first line
+  "FA100",   # future-rewritable-type-annotation
   "PD901",   # pandas-df-variable-name
   "PERF203", # try-except-in-loop
-  # "PERF401", # manual-list-comprehension (TODO fix these or wait for autofix)
+  "PERF401", # manual-list-comprehension (TODO fix these or wait for autofix)
   "PLR",     # pylint refactor
   "PLW2901", # Outer for loop variable overwritten by inner assignment target
   "PT013",   # pytest-incorrect-pytest-import


### PR DESCRIPTION
Closes #514

## Summary

Some logging in the modules `rocket.py` and `rocket_launcher.py` has unexpected behavior. See issue #514 for more details.

Major changes:

- Describe in the docs the logging level used in `rocket.py`
- Replace `print()` with `logger.log()`

## Todos

If this is work in progress, what else needs to be done?

- 

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
