### PR TITLE
DOC: Fix typo in firetask tutorial

### DIFF
--- a/docs_rst/firetask_tutorial.rst
+++ b/docs_rst/firetask_tutorial.rst
@@ -150,7 +150,7 @@ Let's explore custom Firetasks with an example: a custom Python script for addin
            input_array = fw_spec['input_array']
            m_sum = sum(input_array)
 
-           print(f"The sum of {input_array} is: {m_sum}"
+           print(f"The sum of {input_array} is: {m_sum}")
 
            return FWAction(stored_data={'sum': m_sum}, mod_spec=[{'_push': {'input_array': m_sum}}])
 


### PR DESCRIPTION
## Summary

Major changes:

Just fixed a a documentation typo.

## Todos

If this is work in progress, what else needs to be done?

N/A.

## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.
- [X] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```

None of the checklist apply.