### PR TITLE
Fix `lpad.delete_fws` if `fw_id` not found

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -582,7 +582,7 @@ class LaunchPad(FWSerializable):
         for fw_id in fw_ids:
             fw_dict = self.fireworks.find_one({"fw_id": fw_id})
             if fw_dict:
-                potential_launch_ids += fw_dict["launches"] + fw_dict["archived_launches"]
+                potential_launch_ids += fw_dict.get("launches", []) + fw_dict.get("archived_launches", [])
 
         for i in potential_launch_ids:  # only remove launches if no other fws refer to them
             if not self.fireworks.find_one(

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -579,9 +579,10 @@ class LaunchPad(FWSerializable):
         """
         potential_launch_ids = []
         launch_ids = []
-        for i in fw_ids:
-            fw_dict = self.fireworks.find_one({"fw_id": i})
-            potential_launch_ids += fw_dict["launches"] + fw_dict["archived_launches"]
+        for fw_id in fw_ids:
+            fw_dict = self.fireworks.find_one({"fw_id": fw_id})
+            if fw_dict:
+                potential_launch_ids += fw_dict["launches"] + fw_dict["archived_launches"]
 
         for i in potential_launch_ids:  # only remove launches if no other fws refer to them
             if not self.fireworks.find_one(


### PR DESCRIPTION
```py
launchpad.delete_fws([1087263487612])

File ~/dev/fireworks/fireworks/core/launchpad.py:584, in LaunchPad.delete_fws(self, fw_ids, delete_launch_dirs)
    582     fw_dict = self.fireworks.find_one({"fw_id": fw_id})
    583     # if fw_dict:
--> 584     potential_launch_ids += fw_dict["launches"] + fw_dict["archived_launches"]
    586 launch_ids = [
    587     launch_id
    588     for launch_id in potential_launch_ids
   (...)
    592     )
    593 ]
    595 if delete_launch_dirs:

TypeError: 'NoneType' object is not subscriptable
```