### PR TITLE
Migrate CI tests from CircleCI to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,35 +26,7 @@ jobs:
             pip install .[workflow-checks,graph-plotting,flask-plotting]
             pytest fireworks
 
-  pytest_pymongo4:
-    working_directory: ~/fireworks
-    docker:
-      - image: continuumio/miniconda3:4.6.14
-      - image: circleci/mongo:latest
-    steps:
-      - checkout
-      - run:
-          command: |
-            export PATH=$HOME/miniconda3/bin:$PATH
-            conda config --set always_yes yes --set changeps1 no
-            conda update -q conda
-            conda info -a
-            conda create -q -n test-environment python=3.8
-            source activate test-environment
-            conda update --quiet --all
-            pip install --quiet --ignore-installed -r requirements.txt -r requirements-ci.txt
-      - run:
-          name: Run fireworks tests
-          command: |
-            export PATH=$HOME/miniconda3/bin:$PATH
-            source activate test-environment
-            pip install --quiet -e .
-            pip install --quiet --upgrade pymongo
-            pytest fireworks
-
 workflows:
   version: 2
   build_and_test:
-    jobs:
-      - pytest
-      - pytest_pymongo4
+    jobs: [pytest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    services:
+      mongodb:
+        image: mongo
+        ports:
+          - 27017:27017
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: 3.8
+          activate-environment: test-environment
+
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          conda info -a
+          pip install --ignore-installed -r requirements.txt -r requirements-ci.txt
+
+      - name: Run fireworks tests
+        shell: bash -l {0}
+        run: |
+          pip install .[workflow-checks,graph-plotting,flask-plotting]
+          pytest fireworks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Test
 
 on:
   push:
@@ -17,20 +17,17 @@ jobs:
           - 27017:27017
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          auto-update-conda: true
           python-version: 3.8
-          activate-environment: test-environment
 
       - name: Install dependencies
-        shell: bash -l {0}
         run: |
-          conda info -a
-          pip install --ignore-installed -r requirements.txt -r requirements-ci.txt
+          pip install -r requirements.txt -r requirements-ci.txt
 
       - name: Run fireworks tests
         shell: bash -l {0}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ruamel.yaml==0.16.5
-pymongo==3.10.0
+pymongo==4.0.0
 Jinja2
 monty==3.0.2
 python-dateutil==2.8.1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
         python_requires=">=3.8",
         install_requires=[
             "ruamel.yaml>=0.15.35",
-            "pymongo>=3.3.0",
+            "pymongo>=4.0.0",
             "Jinja2>=2.8.0",
             "monty>=1.0.1",
             "python-dateutil>=2.5.3",


### PR DESCRIPTION
also bump `pymongo` to v4.0.0 in `requirements.txt` and `setup.py`

CircleCI was running largely (fully?) identical `pytest` and `pytest_pymongo4` jobs (i.e. duplicate work). now running single job but in both GitHub Action and CircleCI with `pymongo` 4. we can safely remove CircleCI but i don't have permissions