### PR TITLE
Replace copy_tree from distutils with copytree from shutil

### DIFF
--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -5,7 +5,6 @@ completes the Launch.
 
 from __future__ import annotations
 
-import distutils.dir_util
 import errno
 import glob
 import json
@@ -201,7 +200,7 @@ class Rocket:
                             logging.INFO,
                             f"Copying data from recovery folder {recovery_dir} to folder {launch_dir}.",
                         )
-                    distutils.dir_util.copy_tree(recovery_dir, launch_dir, update=1)
+                    shutil.copytree(recovery_dir, launch_dir, dirs_exist_ok=True)
 
             else:
                 starting_task = 0


### PR DESCRIPTION
Closes #532

## Summary

Major changes:

- Fix: replace `copy_tree` from deprecated `distutils` package with `copytree` from the `shutil` package

## Todos

If this is work in progress, what else needs to be done?


## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
