### PR TITLE
Fix recover_offline error: replace deprecated count() with countDocum…

### DIFF
--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -752,7 +752,7 @@ def recover_offline(args: Namespace) -> None:
     recovered_fws = []
 
     for launch in lp.offline_runs.find({"completed": False, "deprecated": False}, {"launch_id": 1, "fw_id": 1}):
-        if fworker_name and lp.launches.count({"launch_id": launch["launch_id"], "fworker.name": fworker_name}) == 0:
+        if fworker_name and lp.launches.count_documents({"launch_id": launch["launch_id"], "fworker.name": fworker_name}) == 0:
             continue
         fw = lp.recover_offline(launch["launch_id"], args.ignore_errors, args.print_errors)
         if fw:


### PR DESCRIPTION
**Title:**  
`Fix: Resolve error in recover_offline for compatibility with MongoDB 4.0+.`

## Summary

**Major changes:**
- **Fix:** Replaced the deprecated `count()` function with `countDocuments()` in the `recover_offline` function to ensure compatibility with MongoDB 4.0+.

This change is required because PyMongo no longer supports the `count()` method. Instead, the `count_documents()` method from the Collection class should be used. For more details, refer to the [PyMongo documentation](https://www.mongodb.com/docs/languages/python/pymongo-driver/current/read/count/#deprecationwarning--count-is-deprecated) and [MongoDB documentation](https://www.mongodb.com/docs/manual/reference/method/db.collection.count/).

## Checklist
- [ ]  I only found the `recover_offline` function with this issue. Other functions, such as `reset`, seem to have already addressed it, but please double-check. Thank you!
