### PR TITLE
Restore default get_njobs_in_queue behavior

### DIFF
--- a/fireworks/user_objects/queue_adapters/common_adapter.py
+++ b/fireworks/user_objects/queue_adapters/common_adapter.py
@@ -236,7 +236,7 @@ class CommonAdapter(QueueAdapterBase):
             # random error, e.g. no qsub on machine!
             log_exception(queue_logger, f"Running the command: {submit_cmd} caused an error...")
 
-    def get_njobs_in_queue(self, username=None):
+    def get_njobs_in_queue(self, username=None, shell : bool = False):
         """
         returns the number of jobs currently in the queue for the user.
 
@@ -251,7 +251,7 @@ class CommonAdapter(QueueAdapterBase):
 
         # run qstat
         qstat = Command(self._get_status_cmd(username))
-        p = qstat.run(timeout=self.timeout, shell=True)
+        p = qstat.run(timeout=self.timeout, shell=shell)
 
         # parse the result
         if p[0] == 0:


### PR DESCRIPTION
Recently, the `get_njobs_in_queue` was [recently updated in v2.0.4](https://github.com/materialsproject/fireworks/pull/492) to use `shell=True` all the time when calling `qstat`. That seems to not work in practice, as running:
```
python -c 'from fireworks.user_objects.queue_adapters.common_adapter import CommonAdapter ; print(CommonAdapter("SLURM").get_njobs_in_queue())'
```
returns say thousands of jobs, which is the total number of jobs running in the queue, rather than the number I expect to see. (Specifying the username explicitly also doesn't work.)

Just making this optional, with the default behavior set to `shell=False`