### PR TITLE
Module not found error no module named pytest

### DIFF
--- a/docs_rst/config_tutorial.rst
+++ b/docs_rst/config_tutorial.rst
@@ -77,6 +77,7 @@ A few basic parameters that can be tweaked are:
 * ``WEBSERVER_PORT: 5000`` - the default port on which to run the web server
 * ``QUEUE_JOBNAME_MAXLEN: 20`` - the max length of the job name to send to the queuing system (some queuing systems limit the size of job names)
 * ``MONGOMOCK_SERVERSTORE_FILE`` - path to a non-empty JSON file, if set then mongomock will be used instead of MongoDB; this file should be initialized with '{}'
+* ``STREAM_LOGLEVEL: INFO`` - the default streaming log level used by loggers (valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL)
 * ``ROCKET_STREAM_LOGLEVEL: INFO`` - the streaming log level of the rocket launcher logger (valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL)
 
 Parameters that you probably shouldn't change

--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -31,6 +31,7 @@ from fireworks.fw_config import (
     SORT_FWS,
     WFLOCK_EXPIRATION_KILL,
     WFLOCK_EXPIRATION_SECS,
+    STREAM_LOGLEVEL
 )
 from fireworks.utilities.fw_serializers import FWSerializable, reconstitute_dates, recursive_dict
 from fireworks.utilities.fw_utilities import get_fw_logger
@@ -190,7 +191,7 @@ class LaunchPad(FWSerializable):
 
         # set up logger
         self.logdir = logdir
-        self.strm_lvl = strm_lvl or "INFO"
+        self.strm_lvl = strm_lvl or STREAM_LOGLEVEL
         self.m_logger = get_fw_logger("launchpad", l_dir=self.logdir, stream_level=self.strm_lvl)
 
         self.user_indices = user_indices or []

--- a/fireworks/core/rocket_launcher.py
+++ b/fireworks/core/rocket_launcher.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from fireworks.core.fworker import FWorker
 from fireworks.core.rocket import Rocket
-from fireworks.fw_config import FWORKER_LOC, RAPIDFIRE_SLEEP_SECS
+from fireworks.fw_config import FWORKER_LOC, RAPIDFIRE_SLEEP_SECS, STREAM_LOGLEVEL
 from fireworks.utilities.fw_utilities import create_datestamp_dir, get_fw_logger, log_multi, redirect_local
 
 if TYPE_CHECKING:
@@ -32,7 +32,7 @@ def get_fworker(fworker):
     return my_fwkr
 
 
-def launch_rocket(launchpad, fworker=None, fw_id=None, strm_lvl="INFO", pdb_on_exception=False):
+def launch_rocket(launchpad, fworker=None, fw_id=None, strm_lvl=STREAM_LOGLEVEL, pdb_on_exception=False):
     """
     Run a single rocket in the current directory.
 
@@ -64,7 +64,7 @@ def rapidfire(
     nlaunches: int = 0,
     max_loops: int = -1,
     sleep_time: int | None = None,
-    strm_lvl: str = "INFO",
+    strm_lvl: str = STREAM_LOGLEVEL,
     timeout: int | None = None,
     local_redirect: bool = False,
     pdb_on_exception: bool = False,

--- a/fireworks/fw_config.py
+++ b/fireworks/fw_config.py
@@ -66,6 +66,7 @@ QUEUEADAPTER_LOC = None  # where to find the my_qadapter.yaml file
 
 CONFIG_FILE_DIR = "."  # directory containing config files (if not individually set)
 
+STREAM_LOGLEVEL = "INFO"  # the default streaming log level used for various loggers
 ROCKET_STREAM_LOGLEVEL = "INFO"  # the streaming log level of the rocket.launcher logger
 
 QSTAT_FREQUENCY = 50  # set this higher to avoid qstats, lower to always

--- a/fireworks/queue/queue_launcher.py
+++ b/fireworks/queue/queue_launcher.py
@@ -21,6 +21,7 @@ from fireworks.fw_config import (
     QUEUE_UPDATE_INTERVAL,
     RAPIDFIRE_SLEEP_SECS,
     SUBMIT_SCRIPT_NAME,
+    STREAM_LOGLEVEL
 )
 from fireworks.utilities.fw_serializers import load_object
 from fireworks.utilities.fw_utilities import create_datestamp_dir, get_fw_logger, get_slug, log_exception
@@ -38,7 +39,7 @@ def launch_rocket_to_queue(
     qadapter,
     launcher_dir=".",
     reserve=False,
-    strm_lvl="INFO",
+    strm_lvl=STREAM_LOGLEVEL,
     create_launcher_dir=False,
     fill_mode=False,
     fw_id=None,
@@ -176,7 +177,7 @@ def rapidfire(
     njobs_block=500,
     sleep_time=None,
     reserve=False,
-    strm_lvl="INFO",
+    strm_lvl=STREAM_LOGLEVEL,
     timeout=None,
     fill_mode=False,
 ) -> None:

--- a/fireworks/scripts/lpad_run.py
+++ b/fireworks/scripts/lpad_run.py
@@ -33,6 +33,7 @@ from fireworks.fw_config import (
     RUN_EXPIRATION_SECS,
     WEBSERVER_HOST,
     WEBSERVER_PORT,
+    STREAM_LOGLEVEL
 )
 from fireworks.user_objects.firetasks.script_task import ScriptTask
 from fireworks.utilities.fw_serializers import DATETIME_HANDLER, recursive_dict
@@ -1368,7 +1369,7 @@ def lpad(argv: Sequence[str] | None = None) -> int:
         default=CONFIG_FILE_DIR,
     )
     parser.add_argument("--logdir", help="path to a directory for logging")
-    parser.add_argument("--loglvl", help="level to print log messages", default="INFO")
+    parser.add_argument("--loglvl", help="level to print log messages", default=STREAM_LOGLEVEL)
     parser.add_argument("-s", "--silencer", help="shortcut to mute log messages", action="store_true")
 
     webgui_parser = subparsers.add_parser("webgui", help="launch the web GUI")

--- a/fireworks/scripts/mlaunch_run.py
+++ b/fireworks/scripts/mlaunch_run.py
@@ -10,7 +10,7 @@ from typing import Sequence
 from fireworks.core.fworker import FWorker
 from fireworks.core.launchpad import LaunchPad
 from fireworks.features.multi_launcher import launch_multiprocess
-from fireworks.fw_config import CONFIG_FILE_DIR, FWORKER_LOC, LAUNCHPAD_LOC
+from fireworks.fw_config import CONFIG_FILE_DIR, FWORKER_LOC, LAUNCHPAD_LOC, STREAM_LOGLEVEL
 
 from ._helpers import _validate_config_file_paths
 
@@ -50,7 +50,7 @@ def mlaunch(argv: Sequence[str] | None = None) -> int:
         default=CONFIG_FILE_DIR,
     )
 
-    parser.add_argument("--loglvl", help="level to print log messages", default="INFO")
+    parser.add_argument("--loglvl", help="level to print log messages", default=STREAM_LOGLEVEL)
     parser.add_argument("-s", "--silencer", help="shortcut to mute log messages", action="store_true")
 
     parser.add_argument(

--- a/fireworks/scripts/qlaunch_run.py
+++ b/fireworks/scripts/qlaunch_run.py
@@ -21,7 +21,13 @@ from importlib import metadata
 
 from fireworks.core.fworker import FWorker
 from fireworks.core.launchpad import LaunchPad
-from fireworks.fw_config import CONFIG_FILE_DIR, FWORKER_LOC, LAUNCHPAD_LOC, QUEUEADAPTER_LOC
+from fireworks.fw_config import (
+    CONFIG_FILE_DIR,
+    FWORKER_LOC,
+    LAUNCHPAD_LOC,
+    QUEUEADAPTER_LOC,
+    STREAM_LOGLEVEL
+)
 from fireworks.queue.queue_launcher import launch_rocket_to_queue, rapidfire
 from fireworks.utilities.fw_serializers import load_object_from_file
 
@@ -155,7 +161,7 @@ def qlaunch(argv: Sequence[str] | None = None) -> int:
         "--block_dir", help="directory to use as block dir. Can be a new or existing block. Must start with 'block_'"
     )
     parser.add_argument("--logdir", help="path to a directory for logging", default=None)
-    parser.add_argument("--loglvl", help="level to print log messages", default="INFO")
+    parser.add_argument("--loglvl", help="level to print log messages", default=STREAM_LOGLEVEL)
     parser.add_argument("-s", "--silencer", help="shortcut to mute log messages", action="store_true")
     parser.add_argument("-r", "--reserve", help="reserve a fw", action="store_true")
     parser.add_argument("-l", "--launchpad_file", help="path to launchpad file")

--- a/fireworks/scripts/rlaunch_run.py
+++ b/fireworks/scripts/rlaunch_run.py
@@ -13,7 +13,7 @@ from fireworks.core.fworker import FWorker
 from fireworks.core.launchpad import LaunchPad
 from fireworks.core.rocket_launcher import launch_rocket, rapidfire
 from fireworks.features.multi_launcher import launch_multiprocess
-from fireworks.fw_config import CONFIG_FILE_DIR, FWORKER_LOC, LAUNCHPAD_LOC
+from fireworks.fw_config import CONFIG_FILE_DIR, FWORKER_LOC, LAUNCHPAD_LOC, STREAM_LOGLEVEL
 from fireworks.utilities.fw_utilities import get_fw_logger, get_my_host, get_my_ip
 
 from ._helpers import _validate_config_file_paths
@@ -110,7 +110,7 @@ def rlaunch(argv: Sequence[str] | None = None) -> int:
         default=CONFIG_FILE_DIR,
     )
 
-    parser.add_argument("--loglvl", help="level to print log messages", default="INFO")
+    parser.add_argument("--loglvl", help="level to print log messages", default=STREAM_LOGLEVEL)
     parser.add_argument("-s", "--silencer", help="shortcut to mute log messages", action="store_true")
 
     try:
@@ -144,7 +144,7 @@ def rlaunch(argv: Sequence[str] | None = None) -> int:
     fworker = FWorker.from_file(args.fworker_file) if args.fworker_file else FWorker()
 
     # prime addr lookups
-    _log = get_fw_logger("rlaunch", stream_level="INFO")
+    _log = get_fw_logger("rlaunch", stream_level=STREAM_LOGLEVEL)
     _log.info("Hostname/IP lookup (this will take a few seconds)")
     get_my_host()
     get_my_ip()

--- a/fireworks/utilities/filepad.py
+++ b/fireworks/utilities/filepad.py
@@ -13,7 +13,7 @@ from monty.serialization import loadfn
 from bson.objectid import ObjectId
 
 from fireworks.fw_config import MongoClient
-from fireworks.fw_config import LAUNCHPAD_LOC, MONGO_SOCKET_TIMEOUT_MS
+from fireworks.fw_config import LAUNCHPAD_LOC, MONGO_SOCKET_TIMEOUT_MS, STREAM_LOGLEVEL
 from fireworks.utilities.fw_utilities import get_fw_logger
 
 __author__ = "Kiran Mathew"
@@ -100,7 +100,7 @@ class FilePad(MSONable):
 
         # logging
         self.logdir = logdir
-        self.strm_lvl = strm_lvl or "INFO"
+        self.strm_lvl = strm_lvl or STREAM_LOGLEVEL
         self.logger = get_fw_logger("filepad", l_dir=self.logdir, stream_level=self.strm_lvl)
 
         # build indexes

--- a/fireworks/utilities/fw_serializers.py
+++ b/fireworks/utilities/fw_serializers.py
@@ -32,13 +32,13 @@ import importlib
 import inspect
 import json  # note that ujson is faster, but at this time does not support "default" in dumps()
 import pkgutil
-import traceback
 from typing import NoReturn
 
 from monty.json import MontyDecoder, MSONable
 from ruamel.yaml import YAML
 from ruamel.yaml.compat import StringIO
 
+from fireworks.utilities.fw_utilities import get_fw_logger
 from fireworks.fw_config import (
     DECODE_MONTY,
     ENCODE_MONTY,
@@ -47,6 +47,7 @@ from fireworks.fw_config import (
     JSON_SCHEMA_VALIDATE_LIST,
     USER_PACKAGES,
     YAML_STYLE,
+    STREAM_LOGLEVEL
 )
 
 __author__ = "Anubhav Jain"
@@ -370,10 +371,8 @@ def load_object(obj_dict):
                 if m_object is not None:
                     found_objects.append((m_object, mod_name))
             except ImportError as ex:
-                import warnings
-
-                warnings.warn(f"{m_object} in {mod_name} cannot be loaded because of {ex!s}. Skipping..")
-                traceback.print_exc()
+                msg = f"{m_object} in {mod_name} cannot be loaded because of {ex!s}. Skipping.."
+                get_fw_logger(__name__, stream_level=STREAM_LOGLEVEL).debug(msg)
 
     if len(found_objects) == 1:
         SAVED_FW_MODULES[fw_name] = found_objects[0][1]


### PR DESCRIPTION
Closes #535 

## Summary

Major changes:

- fix 1: do not print a warning but a log message (with the original text) at the debug level, Python traceback omitted
- fix 2: set a default streaming log level in `fw_config.py` and use this in fix 1  because no global value for the log level available
- change 1: reuse the default streaming log level in all other modules in the package where "INFO" has been used as default (second commit).
- change 2: adapted the docs for fix 2 and change 1.

## Todos
None.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
