### PR TITLE
Use LazyFirework object to construct Workflow for extending

### DIFF
--- a/fireworks/core/launchpad.py
+++ b/fireworks/core/launchpad.py
@@ -453,7 +453,7 @@ class LaunchPad(FWSerializable):
             pull_spec_mods (bool): Whether the new Workflow should pull the FWActions of the parent
                 fw_ids
         """
-        wf = self.get_wf_by_fw_id(fw_ids[0])
+        wf = self.get_wf_by_fw_id_lzyfw(fw_ids[0])
         updated_ids = wf.append_wf(new_wf, fw_ids, detour=detour, pull_spec_mods=pull_spec_mods)
         with WFLock(self, fw_ids[0]):
             self._update_wf(wf, updated_ids)


### PR DESCRIPTION
Closes #544 
 
## Summary

Major changes:

- feature 1: use LazyFirework in `LaunchPad.append_wf()`

## Todos

None

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
