### PR TITLE
[Feature Request]: Improve behavior of ‎FWSerializable.to_file

### DIFF
--- a/fireworks/fw_config.py
+++ b/fireworks/fw_config.py
@@ -45,7 +45,7 @@ PRINT_FW_JSON = True
 PRINT_FW_YAML = False
 
 JSON_SCHEMA_VALIDATE = False
-JSON_SCHEMA_VALIDATE_LIST = None
+JSON_SCHEMA_VALIDATE_LIST = []
 
 PING_TIME_SECS = 3600  # while Running a job, how often to ping back the server that we're still alive
 RUN_EXPIRATION_SECS = PING_TIME_SECS * 4  # mark job as FIZZLED if not pinged in this time

--- a/fireworks/utilities/fw_serializers.py
+++ b/fireworks/utilities/fw_serializers.py
@@ -275,18 +275,19 @@ class FWSerializable(abc.ABC):
             filename(str): filename to write to
             f_format (str): serialization format, default checks the filename extension
         """
+        dct = self.to_dict()
         if f_format is None:
             f_format = filename.split(".")[-1]
+        if f_format not in ("json", "yaml"):
+            raise ValueError(f"Unsupported format {f_format}")
         with open(filename, "w", **ENCODING_PARAMS) as f_out:
             if f_format == "json":
-                json.dump(self.to_dict(), f_out, default=DATETIME_HANDLER, **kwargs)
-            elif f_format == "yaml":
+                json.dump(dct, f_out, default=DATETIME_HANDLER, **kwargs)
+            else:
                 yaml = YAML(typ="safe", pure=True)
                 yaml.default_flow_style = YAML_STYLE
                 yaml.allow_unicode = True
-                yaml.dump(self.to_dict(), f_out)
-            else:
-                raise ValueError(f"Unsupported format {f_format}")
+                yaml.dump(dct, f_out)
 
     @classmethod
     def from_file(cls, filename, f_format=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ upload-dir = docs/_build/html
 [aliases]
 upload_docs = upload_docs --upload-dir=docs/_build/html
 release = register sdist upload
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
Closes #546 

## Summary

Major changes:

- feature 1: Separate `to_dict()` from the actual serialization to YAML/JSON and writing to file.
- fix 1: flake8 E501 line too long
- fix 2: pylint E1135 unsupported-membership-test

## Todos

None

## Checklist

- [ ] ~Google format doc strings added. Check with `ruff`.~
- [ ] ~Type annotations included. Check with `mypy`.~
- [ ] ~Tests added for new features/fixes.~
- [ ] ~If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))~

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
