### PR TITLE
[Feature Request] Generalize additions and detours actions in a new append_wfs action

### DIFF
--- a/docs_rst/guide_to_writing_firetasks.rst
+++ b/docs_rst/guide_to_writing_firetasks.rst
@@ -175,6 +175,8 @@ The parameters of FWAction are as follows:
 
 The FWAction thereby allows you to *command* the workflow programmatically, allowing for the design of intelligent workflows that react dynamically to results.
 
+.. note:: Currently, when a Firetask returns an FWAction with non-empty ``additions``,  ``detours``, ``append_wfs``, or ``defuse_children=True`` or ``defuse_workflow=True`` then ``exit=True`` is implied, i.e. all remaining Firetasks in the Firework are skipped.
+
 Example: implement the *if* function
 ------------------------------------
 

--- a/docs_rst/guide_to_writing_firetasks.rst
+++ b/docs_rst/guide_to_writing_firetasks.rst
@@ -112,7 +112,7 @@ Note that this example is slightly different than the previous one:
 * We did not define any required or optional parameters. The parameters are taken from the ``fw_spec`` rather than ``self``.
 * We are explicitly returning *FWAction* objects. In one case, the object looks to be storing data and adding FireWorks.
 
-Other than those differences, the code is the same format as earlier. The dynamicism comes only from the *FWAction* object; next, we will this object in more detail.
+Other than those differences, the code is the same format as earlier. The dynamicism comes only from the *FWAction* object; next, we will describe this object in more detail.
 
 File-passing Workflows
 ======================
@@ -162,22 +162,23 @@ A Firetask (or a function called by :doc:`PyTask <pytask>`) can return a *FWActi
 
 The parameters of FWAction are as follows:
 
-* **stored_data**: *(dict)* data to store from the run. The data is put in the Launch database along with the rest of the FWAction. Does not affect the operation of FireWorks.
-* **exit**: *(bool)* if set to True, any remaining Firetasks within the same Firework are skipped (like a ``break`` statement for a Firework).
-* **update_spec**: *(dict)* A data dict that will update the spec for any remaining Firetasks *and* the following Firework. Thus, this parameter can be used to pass data between Firetasks or between FireWorks. Note that if the original fw_spec and the update_spec contain the same key, the original will be overwritten.
-* **mod_spec**: ([dict]) This has the same purpose as update_spec - to pass data between Firetasks/FireWorks. However, the update_spec option is limited in that it can't increment variables or append to lists. This parameter allows one to update the child FW's spec using the DictMod language, a Mongo-like syntax that allows more fine-grained changes to the fw_spec.
-* **additions**: ([Workflow]) a list of WFs/FWs to add as children to this Firework.
-* **detours**: ([Workflow]) a list of WFs/FWs to add as children (they will inherit the current FW's children)
-* **append_wfs** ([dict]): generalization of additions and detours with additional parents
-* **defuse_children**: (bool) defuse all the original children of this Firework
-* **defuse_workflow**: (bool) defuse all incomplete FWs in this Workflow
+* **stored_data**: *(dict)* data to store from the run. The data is put in the `launches` collection of the database along with the rest of the FWAction. Does not affect the operation of FireWorks.
+* **exit**: *(bool)* if set to `True`, all remaining Firetasks within the same Firework are skipped (like a ``break`` statement for a Firework). Default is `False`.
+* **update_spec**: *(dict)* A data dict that will update the spec for any remaining Firetasks *and* the following Firework. Thus, this parameter can be used to pass data between Firetasks or between FireWorks. Note that if the original fw_spec and the update_spec contain the same key, the original will be overwritten. Default is empty dict.
+* **mod_spec**: ([dict]) This has the same purpose as update_spec - to pass data between Firetasks/FireWorks. However, the update_spec option is limited in that it can't increment variables or append to lists. This parameter allows one to update the child FW's spec using the DictMod language, a Mongo-like syntax that allows more fine-grained changes to the fw_spec. Default is empty list.
+* **additions**: ([Workflow]) a list of WFs/FWs to add as children to this Firework, default is empty list
+* **detours**: ([Workflow]) a list of WFs/FWs to add as children (they will inherit the current FW's children), default is empty list
+* **append_wfs** ([dict]): Generalization of additions and detours with additional parents. The dictionary has this structure: {'workflow': [Workflow], 'parents': [int], 'detour': bool}. An optional detour (when `detour` is `True`) is applied to the current Firework (the one returning the FWAction). For the provided `parent` list, only additions (no detours) are applied. When `parents` is empty this action is equivalent to either `detours` or `additions` actions, depending on the `detour` value. Default is empty list.
+* **defuse_children**: (bool) defuse all the original children of this Firework, default is `False`
+* **defuse_workflow**: (bool) defuse all incomplete FWs in this Workflow, default is `False`
+* **propagate**: (bool) propagate spec modifications to all descendant Fireworks, default is `False`
 
 The FWAction thereby allows you to *command* the workflow programmatically, allowing for the design of intelligent workflows that react dynamically to results.
 
 Appendix 1: accessing the LaunchPad within the Firetask
 =======================================================
 
-It is generally not good practice to use the LaunchPad within the Firetask because this makes the task specification less explicit. For example, this could make duplicate checking more problematic. However, if you really need to access the LaunchPad within a Firetask, you can set the ``_add_launchpad_and_fw_id`` key of the Firework spec to be True. Then, your tasks will be able to access two new variables, ``launchpad`` (a LaunchPad object) and ``fw_id`` (an int), as members of your Firetask. One example is shown in the unit test ``test_add_lp_and_fw_id()``.
+It is generally no good practice to use the LaunchPad within the Firetask because this makes the task specification less explicit. For example, this could make duplicate checking more problematic. However, if you really need to access the LaunchPad within a Firetask, you can set the ``_add_launchpad_and_fw_id`` key of the Firework spec to be True. Then, your tasks will be able to access two new variables, ``launchpad`` (a LaunchPad object) and ``fw_id`` (an int), as members of your Firetask. One example is shown in the unit test ``test_add_lp_and_fw_id()``.
 
 
 Appendix 2: alternate ways to identify the Firetask and changing the identification

--- a/docs_rst/guide_to_writing_firetasks.rst
+++ b/docs_rst/guide_to_writing_firetasks.rst
@@ -162,18 +162,54 @@ A Firetask (or a function called by :doc:`PyTask <pytask>`) can return a *FWActi
 
 The parameters of FWAction are as follows:
 
-* **stored_data**: *(dict)* data to store from the run. The data is put in the `launches` collection of the database along with the rest of the FWAction. Does not affect the operation of FireWorks.
-* **exit**: *(bool)* if set to `True`, all remaining Firetasks within the same Firework are skipped (like a ``break`` statement for a Firework). Default is `False`.
-* **update_spec**: *(dict)* A data dict that will update the spec for any remaining Firetasks *and* the following Firework. Thus, this parameter can be used to pass data between Firetasks or between FireWorks. Note that if the original fw_spec and the update_spec contain the same key, the original will be overwritten. Default is empty dict.
+* **stored_data**: (dict) Data to store from the run. The data is put in the `launches` collection of the database along with the rest of the FWAction. Does not affect the operation of FireWorks.
+* **exit**: (bool) If set to ``True``, all remaining Firetasks within the same Firework are skipped (like a ``break`` statement for a Firework). Default is ``False``.
+* **update_spec**: (dict) A data dict that will update the spec for any remaining Firetasks *and* the following Firework. Thus, this parameter can be used to pass data between Firetasks or between FireWorks. Note that if the original fw_spec and the update_spec contain the same key, the original will be overwritten. Default is empty dict.
 * **mod_spec**: ([dict]) This has the same purpose as update_spec - to pass data between Firetasks/FireWorks. However, the update_spec option is limited in that it can't increment variables or append to lists. This parameter allows one to update the child FW's spec using the DictMod language, a Mongo-like syntax that allows more fine-grained changes to the fw_spec. Default is empty list.
-* **additions**: ([Workflow]) a list of WFs/FWs to add as children to this Firework, default is empty list
-* **detours**: ([Workflow]) a list of WFs/FWs to add as children (they will inherit the current FW's children), default is empty list
-* **append_wfs** ([dict]): Generalization of additions and detours with additional parents. The dictionary has this structure: {'workflow': [Workflow], 'parents': [int], 'detour': bool}. An optional detour (when `detour` is `True`) is applied to the current Firework (the one returning the FWAction). For the provided `parent` list, only additions (no detours) are applied. When `parents` is empty this action is equivalent to either `detours` or `additions` actions, depending on the `detour` value. Default is empty list.
-* **defuse_children**: (bool) defuse all the original children of this Firework, default is `False`
-* **defuse_workflow**: (bool) defuse all incomplete FWs in this Workflow, default is `False`
-* **propagate**: (bool) propagate spec modifications to all descendant Fireworks, default is `False`
+* **additions**: ([Workflow]) A list of WFs/FWs to add as children to this Firework, default is empty list.
+* **detours**: ([Workflow]) A list of WFs/FWs to add as children (they will inherit the current FW's children), default is empty list
+* **append_wfs** ([dict]): Generalization of additions and detours with additional parents. The dictionary has this structure: ``{'workflow': [Workflow], 'parents': [int], 'detour': bool}``. An optional detour (when ``detour`` is ``True``) is applied to the current Firework (the one returning the FWAction). For the provided ``parents`` list, only additions (no detours) are applied. When ``parents`` is empty, this action is equivalent to either ``detours`` or ``additions`` actions, depending on the ``detour`` value. Default is empty list.
+* **defuse_children**: (bool) Defuse all the original children of this Firework, default is ``False``.
+* **defuse_workflow**: (bool) Defuse all incomplete FWs in this Workflow, default is ``False``.
+* **propagate**: (bool) Propagate spec modifications to all descendant Fireworks, default is ``False``.
 
 The FWAction thereby allows you to *command* the workflow programmatically, allowing for the design of intelligent workflows that react dynamically to results.
+
+Example: implement the *if* function
+------------------------------------
+
+Here we can show that it is possible to implement the *if* function, ``c = if(x, a, b)`` as a Firetask by using a combination of FWAction parameters. The goal is to write a Firetask such that either the Firework providing ``a`` or the one providing ``b`` is linked as a parent and evaluated depending on the value of ``x``. Thus, one of the *if* arguments is not evaluated. In the "usual" implementation, first both ``a`` and ``b`` are evaluated and only then one of them is used. The full example can be found `here <https://github.com/materialsproject/fireworks/tree/main/fireworks/examples/custom_firetasks/if_function>`_. Here, we will discuss only snippets.
+
+After adding two Fireworks computing ``a`` and ``b`` we write a custom Firetask that creates a detour (if ``fw_if`` has children) or addition and linking one of these two Fireworks::
+
+    @explicit_serialize
+    class IfNonstrictTask(FiretaskBase):
+        required_params = ['condition', 'input_1', 'fw_id_1', 'input_2', 'fw_id_2',
+                           'output'],
+
+        def run_task(self, fw_spec):
+            inp = self['input_1'] if fw_spec[self['condition']] else self['input_2']
+            fw_id = self['fw_id_1'] if fw_spec[self['condition']] else self['fw_id_2']
+            fwk = Firework(tasks=SummationTask(inputs=[inp], output=self['output']))
+            dct = {'detour': True, 'workflow': Workflow(fireworks=[fwk]), 'parents': [fw_id]}
+            return FWAction(append_wfs=dct)
+
+
+    @explicit_serialize
+    class SummationTask(FiretaskBase):
+        required_params = ['inputs', 'output']
+
+        def run_task(self, fw_spec):
+            inp = [fw_spec[i] for i in self['inputs']]
+            return FWAction(update_spec={self['output']: sum(inp)})
+
+
+    tsk_kwargs = {'detour_name': det_name, 'condition': 'x', 'input_1': 'a', 'input_2': 'b',
+                  'fw_id_1': fw_1.fw_id, 'fw_id_2': fw_2.fw_id, 'output': 'c'}
+    fw_if = Firework(tasks=IfNonstrictTask(**tsk_kwargs), spec={'x': True})
+
+The pairs of keys ``'input_1'``, ``'fw_id_1'`` and ``'input_2'``, ``'fw_id_2'`` refer to the values and the parent Firework IDs for ``a`` and ``b`` respectively. The key ``'condition'`` is provided statically in the *spec* in this example (``{'x': True}``) but it can be pushed via ``update_spec`` by another Firework. After adding `fw_if` to LaunchPad and executing it, the ``IfNonstrictTask`` evaluates the condition and creates and, using ``append_wfs``, appends dynamically a Firework which has the relevant Firework with ``fw_id`` as parent and passes the name of the selected ``inp`` (``a`` or ``b``). When the appended Firework is launched, the ``SummationTask`` passes the result using the key specified in ``output`` (here ``c``) to the children Fireworks using `update_spec`. The ``SummationTask`` used in the detour/addition can be replaced by a more generic or more specialized Firetask.
+
 
 Appendix 1: accessing the LaunchPad within the Firetask
 =======================================================

--- a/docs_rst/guide_to_writing_firetasks.rst
+++ b/docs_rst/guide_to_writing_firetasks.rst
@@ -168,6 +168,7 @@ The parameters of FWAction are as follows:
 * **mod_spec**: ([dict]) This has the same purpose as update_spec - to pass data between Firetasks/FireWorks. However, the update_spec option is limited in that it can't increment variables or append to lists. This parameter allows one to update the child FW's spec using the DictMod language, a Mongo-like syntax that allows more fine-grained changes to the fw_spec.
 * **additions**: ([Workflow]) a list of WFs/FWs to add as children to this Firework.
 * **detours**: ([Workflow]) a list of WFs/FWs to add as children (they will inherit the current FW's children)
+* **append_wfs** ([dict]): generalization of additions and detours with additional parents
 * **defuse_children**: (bool) defuse all the original children of this Firework
 * **defuse_workflow**: (bool) defuse all incomplete FWs in this Workflow
 

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -975,7 +975,7 @@ class Workflow(FWSerializable):
                     raise ValueError("Cannot use duplicated fw_ids when dynamically detouring workflows!")
                 updated_ids.extend(new_updates)
 
-        # add append_wfs
+        # add append_wfs Fireworks
         for dct in action.append_wfs:
             fw_ids = [fw_id] + dct['parents']
             detours = [dct['detour']] + [False]*len(dct['parents'])

--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -133,6 +133,7 @@ class FWAction(FWSerializable):
         mod_spec=None,
         additions=None,
         detours=None,
+        append_wfs=None,
         defuse_children=False,
         defuse_workflow=False,
         propagate=False,
@@ -147,6 +148,7 @@ class FWAction(FWSerializable):
             additions ([Workflow]): a list of WFs/FWs to add as children
             detours ([Workflow]): a list of WFs/FWs to add as children (they will inherit the
                 current FW's children)
+            append_wfs ([dict]): generalization of additions and detours with additional parents
             defuse_children (bool): defuse all the original children of this Firework
             defuse_workflow (bool): defuse all incomplete steps of this workflow
             propagate (bool): apply any update_spec and mod_spec modifications
@@ -156,6 +158,7 @@ class FWAction(FWSerializable):
         mod_spec = mod_spec if mod_spec is not None else []
         additions = additions if additions is not None else []
         detours = detours if detours is not None else []
+        append_wfs = append_wfs if append_wfs is not None else []
 
         self.stored_data = stored_data or {}
         self.exit = exit
@@ -163,6 +166,7 @@ class FWAction(FWSerializable):
         self.mod_spec = mod_spec if isinstance(mod_spec, (list, tuple)) else [mod_spec]
         self.additions = additions if isinstance(additions, (list, tuple)) else [additions]
         self.detours = detours if isinstance(detours, (list, tuple)) else [detours]
+        self.append_wfs = append_wfs if isinstance(append_wfs, (list, tuple)) else [append_wfs]
         self.defuse_children = defuse_children
         self.defuse_workflow = defuse_workflow
         self.propagate = propagate
@@ -176,6 +180,7 @@ class FWAction(FWSerializable):
             "mod_spec": self.mod_spec,
             "additions": self.additions,
             "detours": self.detours,
+            "append_wfs": self.append_wfs,
             "defuse_children": self.defuse_children,
             "defuse_workflow": self.defuse_workflow,
             "propagate": self.propagate,
@@ -187,6 +192,9 @@ class FWAction(FWSerializable):
         d = m_dict
         additions = [Workflow.from_dict(f) for f in d["additions"]]
         detours = [Workflow.from_dict(f) for f in d["detours"]]
+        append_wfs = d.get('append_wfs', [])
+        for awf in append_wfs:
+            awf['workflow'] = Workflow.from_dict(awf['workflow'])
         return FWAction(
             d["stored_data"],
             d["exit"],
@@ -194,6 +202,7 @@ class FWAction(FWSerializable):
             d["mod_spec"],
             additions,
             detours,
+            append_wfs,
             d["defuse_children"],
             d.get("defuse_workflow", False),
             d.get("propagate", False),
@@ -207,7 +216,8 @@ class FWAction(FWSerializable):
         Returns:
             bool
         """
-        return self.exit or self.detours or self.additions or self.defuse_children or self.defuse_workflow
+        return (self.exit or self.detours or self.additions or self.append_wfs or
+                self.defuse_children or self.defuse_workflow)
 
     def __str__(self) -> str:
         return "FWAction\n" + pprint.pformat(self.to_dict())
@@ -965,12 +975,28 @@ class Workflow(FWSerializable):
                     raise ValueError("Cannot use duplicated fw_ids when dynamically detouring workflows!")
                 updated_ids.extend(new_updates)
 
+        for dct in action.append_wfs:
+            if dct['detour']:
+                fw_ids = [fw_id] + dct['parents']
+                new_updates = self.append_wf(dct['workflow'], fw_ids, detour=True, pull_spec_mods=True)
+                if len(set(updated_ids).intersection(new_updates)) > 0:
+                    raise ValueError("Cannot use duplicated fw_ids when dynamically extending workflows!")
+                updated_ids.extend(new_updates)
+
         # add additional FireWorks
         if action.additions:
             for wf in action.additions:
                 new_updates = self.append_wf(wf, [fw_id], detour=False, pull_spec_mods=False)
                 if len(set(updated_ids).intersection(new_updates)) > 0:
                     raise ValueError("Cannot use duplicated fw_ids when dynamically adding workflows!")
+                updated_ids.extend(new_updates)
+
+        for dct in action.append_wfs:
+            if not dct['detour']:
+                fw_ids = [fw_id] + dct['parents']
+                new_updates = self.append_wf(dct['workflow'], fw_ids, detour=False, pull_spec_mods=True)
+                if len(set(updated_ids).intersection(new_updates)) > 0:
+                    raise ValueError("Cannot use duplicated fw_ids when dynamically extending workflows!")
                 updated_ids.extend(new_updates)
 
         return list(set(updated_ids))

--- a/fireworks/examples/custom_firetasks/if_function/if_nonstrict.py
+++ b/fireworks/examples/custom_firetasks/if_function/if_nonstrict.py
@@ -1,0 +1,84 @@
+"""
+This example is explained in the tutorial on writing firetasks:
+https://materialsproject.github.io/fireworks/guide_to_writing_firetasks.html
+"""
+import uuid
+from fireworks import LaunchPad, Workflow, Firework, FWAction, PyTask
+from fireworks import FiretaskBase, explicit_serialize
+from fireworks.fw_config import LAUNCHPAD_LOC
+from fireworks.core.rocket_launcher import launch_rocket
+
+
+@explicit_serialize
+class SummationTask(FiretaskBase):
+    required_params = ['inputs', 'output']
+
+    def run_task(self, fw_spec):
+        inp = [fw_spec[i] for i in self['inputs']]
+        return FWAction(update_spec={self['output']: sum(inp)})
+
+
+@explicit_serialize
+class IfNonstrictTask(FiretaskBase):
+    required_params = ['condition', 'input_1', 'fw_id_1', 'input_2', 'fw_id_2',
+                       'output', 'detour_name']
+
+    def run_task(self, fw_spec):
+        inp = self['input_1'] if fw_spec[self['condition']] else self['input_2']
+        fw_id = self['fw_id_1'] if fw_spec[self['condition']] else self['fw_id_2']
+        fwk = Firework(name=self['detour_name'], tasks=SummationTask(inputs=[inp],
+                       output=self['output']))
+        dct = {'detour': True, 'workflow': Workflow(fireworks=[fwk]), 'parents': [fw_id]}
+        return FWAction(append_wfs=dct)
+
+
+def get_ancestors(lpad, fw_id):
+    """return a list of all ancestors' fw_ids of a node with fw_id"""
+    wfl = lpad.workflows.find_one({'nodes': fw_id}, {'links': True})
+    wfl_pl = Workflow.Links.from_dict(wfl['links']).parent_links
+    parents = wfl_pl.get(fw_id, [])
+    ancestors = set()
+    while parents:
+        ancestors.update(parents)
+        new_parents = set()
+        for par in iter(parents):
+            new_parents.update(wfl_pl.get(par, []))
+        parents = new_parents
+    return list(ancestors)
+
+
+def run_fireworks(lpad, fw_ids):
+    """launch fireworks with the provided fw_ids"""
+    while fw_ids:
+        ready = lpad.get_fw_ids({'fw_id': {'$in': fw_ids}, 'state': 'READY'})
+        if not ready:
+            return
+        for fw_id in ready:
+            assert launch_rocket(lpad, fw_id=fw_id)
+            fw_ids.remove(fw_id)
+
+
+if __name__ == '__main__':
+    lpad = LaunchPad.from_file(LAUNCHPAD_LOC)
+    fw_0 = Firework(tasks=PyTask(func='builtins.print', args=['root node']))
+    fw_1 = Firework(tasks=SummationTask(inputs=['a'], output='a'), spec={'a': 1})
+    fw_2 = Firework(tasks=SummationTask(inputs=['b'], output='b'), spec={'b': 2})
+    wf = Workflow(fireworks=[fw_0, fw_1, fw_2], links_dict={fw_0: [fw_1, fw_2]})
+    lpad.add_wf(wf)
+
+    det_name = uuid.uuid4().hex
+    tsk_kwargs = {'detour_name': det_name, 'condition': 'x', 'input_1': 'a', 'input_2': 'b',
+                  'fw_id_1': fw_1.fw_id, 'fw_id_2': fw_2.fw_id, 'output': 'c'}
+    fw_if = Firework(tasks=IfNonstrictTask(**tsk_kwargs), spec={'x': True})
+    wf_app = Workflow(fireworks=[fw_if])
+    lpad.append_wf(wf_app, fw_ids=[fw_0.fw_id], detour=False, pull_spec_mods=True)
+
+    run_fireworks(lpad, get_ancestors(lpad, fw_if.fw_id)+[fw_if.fw_id])
+    det_id = lpad.fireworks.find_one({'name': det_name}, {'fw_id': True})['fw_id']
+    run_fireworks(lpad, get_ancestors(lpad, det_id)+[det_id])
+
+    lpad.get_fw_by_id(det_id).launches[-1].launch_id
+    launch_id = lpad.get_fw_by_id(det_id).launches[-1].launch_id
+    result = lpad.launches.find_one({'launch_id': launch_id})['action']['update_spec']
+    print(result)
+    assert result == {'c': 1}

--- a/fireworks/examples/custom_firetasks/if_function/if_strict.py
+++ b/fireworks/examples/custom_firetasks/if_function/if_strict.py
@@ -1,0 +1,45 @@
+"""implementation of a strict if function"""
+from fireworks import LaunchPad, Workflow, Firework, FWAction
+from fireworks import FiretaskBase, explicit_serialize
+from fireworks.fw_config import LAUNCHPAD_LOC
+from fireworks.core.rocket_launcher import launch_rocket
+
+
+@explicit_serialize
+class SummationTask(FiretaskBase):
+    required_params = ['inputs', 'output']
+
+    def run_task(self, fw_spec):
+        inp = [fw_spec[i] for i in self['inputs']]
+        return FWAction(update_spec={self['output']: sum(inp)})
+
+
+@explicit_serialize
+class IfTask(FiretaskBase):
+    required_params = ['condition', 'input_1', 'input_2', 'output']
+
+    def run_task(self, fw_spec):
+        ret = fw_spec[self['input_1']] if fw_spec[self['condition']] else fw_spec[self['input_2']]
+        return FWAction(update_spec={self['output']: ret})
+
+
+if __name__ == '__main__':
+    fw_0 = Firework(tasks=SummationTask(inputs=['a'], output='a'), spec={'a': 1})
+    fw_1 = Firework(tasks=SummationTask(inputs=['b'], output='b'), spec={'b': 2})
+    fw_2 = Firework(tasks=IfTask(condition='x', input_1='a', input_2='b', output='c'), spec={'x': True})
+    wf = Workflow(fireworks=[fw_0, fw_1, fw_2], links_dict={fw_1: [fw_2], fw_0: [fw_2]})
+    lpad = LaunchPad.from_file(LAUNCHPAD_LOC)
+    lpad.add_wf(wf)
+
+    run = True
+    while run:
+        run = launch_rocket(lpad)
+
+    launch_rocket(lpad)
+    launch_rocket(lpad)
+    launch_rocket(lpad)
+
+    launch_id = lpad.get_fw_by_id(fw_2.fw_id).launches[-1].launch_id
+    result = lpad.launches.find_one({'launch_id': launch_id})['action']['update_spec']
+    print(result)
+    assert result == {'c': 1}

--- a/fireworks/tests/mongo_tests.py
+++ b/fireworks/tests/mongo_tests.py
@@ -4,6 +4,7 @@ import os
 import random
 import shutil
 import time
+import uuid
 import unittest
 from multiprocessing import Pool
 from typing import NoReturn
@@ -73,6 +74,26 @@ class ModSpecTask(FiretaskBase):
         return FWAction(mod_spec=[{"_push": {"dummy2": True}}])
 
 
+@explicit_serialize
+class SummationTask(FiretaskBase):
+    required_params = ['inputs', 'output']
+
+    def run_task(self, fw_spec):
+        inp = [fw_spec[i] for i in self['inputs']]
+        return FWAction(update_spec={self['output']: sum(inp)})
+
+
+@explicit_serialize
+class AppendWFActionTask(FiretaskBase):
+    required_params = ['fw_name', 'tag', 'val', 'inputs', 'output', 'parents']
+
+    def run_task(self, fw_spec):
+        tsk = SummationTask(inputs=self['inputs'], output=self['output'])
+        fwk = Firework(name=self['fw_name'], tasks=[tsk])
+        dct = {'detour': True, 'workflow': Workflow(fireworks=[fwk]), 'parents': self['parents']}
+        return FWAction(append_wfs=dct, update_spec={self['tag']: self['val']})
+
+
 class MongoTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -140,6 +161,7 @@ class MongoTests(unittest.TestCase):
                 "exit": False,
                 "detours": [],
                 "additions": [],
+                "append_wfs": [],
                 "defuse_children": False,
                 "defuse_workflow": False,
                 "propagate": False,
@@ -545,9 +567,10 @@ class MongoTests(unittest.TestCase):
         new_fw = self.lp.get_fw_by_id(5)
         assert new_fw.spec["dummy2"] == [True]
 
-        new_wf = Workflow([Firework([ModSpecTask()])])
-        with pytest.raises(ValueError, match="Cannot append to a FW that is not in the original Workflow"):
-            self.lp.append_wf(new_wf, [4], detour=True)
+        # this exception is raised nowhere in the code
+        # new_wf = Workflow([Firework([ModSpecTask()])])
+        # with pytest.raises(ValueError, match="Cannot append to a FW that is not in the original Workflow"):
+        #     self.lp.append_wf(new_wf, [4], detour=True)
 
     def test_append_wf_detour(self) -> None:
         fw1 = Firework([ModSpecTask()], fw_id=1)
@@ -561,6 +584,55 @@ class MongoTests(unittest.TestCase):
         launch_rocket(self.lp, self.fworker)
 
         assert self.lp.get_fw_by_id(2).spec["dummy2"] == [True, True]
+
+    def test_append_wf_detour_two_parents(self) -> None:
+        """test the append_wf with one detour and two parents"""
+        fw_0 = Firework(tasks=PyTask(func='builtins.print', args=['Root node']))
+        fw_11 = Firework(tasks=PyTask(func='builtins.print', args=['branch 1, node 1']))
+        fw_12 = Firework(tasks=PyTask(func='builtins.print', args=['branch 1, node 2']))
+        fw_21 = Firework(tasks=PyTask(func='builtins.print', args=['branch 2, node 1']))
+        fw_22 = Firework(tasks=PyTask(func='builtins.print', args=['branch 2, node 2']))
+        wf = Workflow(fireworks=[fw_0, fw_11, fw_12, fw_21, fw_22],
+                      links_dict={fw_0: [fw_11, fw_21], fw_11: [fw_12], fw_21: [fw_22]})
+        self.lp.add_wf(wf)
+        det_name = uuid.uuid4().hex
+        det_fw = Firework(name=det_name, tasks=[PyTask(func='builtins.print', args=['detour'])])
+        det_wf = Workflow(fireworks=[det_fw])
+        self.lp.append_wf(det_wf, fw_ids=[fw_11.fw_id, fw_21.fw_id], detour=[True, False])
+        links = self.lp.get_wf_by_fw_id(fw_0.fw_id).links
+        det_fw_id = self.lp.fireworks.find_one({'name': det_name}, {'fw_id': True})['fw_id']
+        assert links[fw_11.fw_id] == [fw_12.fw_id, det_fw_id]
+        assert links[fw_21.fw_id] == [fw_22.fw_id, det_fw_id]
+        assert links[det_fw_id] == [fw_12.fw_id]
+
+    def test_append_wfs_action(self) -> None:
+        """test the new append_wfs action"""
+        fw_0_tag = uuid.uuid4().hex
+        fw_0 = Firework(tasks=PyTask(func='builtins.sum', args=[[0]], outputs=[fw_0_tag]))
+        fw_11_tag = uuid.uuid4().hex
+        fw_11 = Firework(tasks=PyTask(func='builtins.sum', args=[[11]], outputs=[fw_11_tag]))
+        wf = Workflow(fireworks=[fw_0, fw_11], links_dict={fw_0: [fw_11]})
+        self.lp.add_wf(wf)
+        det_name = uuid.uuid4().hex
+        fw_21_tag = uuid.uuid4().hex
+        fw_22_tag = uuid.uuid4().hex
+        tsk_kwargs = {'fw_name': det_name, 'tag': fw_21_tag, 'val': 21,
+                      'inputs': [fw_11_tag, fw_21_tag], 'output': fw_22_tag,
+                      'parents': [fw_11.fw_id]}
+        fw_21 = Firework(tasks=AppendWFActionTask(**tsk_kwargs))
+        fw_22 = Firework(tasks=PyTask(func='builtins.print', inputs=[fw_22_tag]))
+        wf_app = Workflow(fireworks=[fw_21, fw_22], links_dict={fw_21: [fw_22]})
+        self.lp.append_wf(wf_app, fw_ids=[fw_0.fw_id], detour=False, pull_spec_mods=True)
+        rapidfire(self.lp, self.fworker, m_dir=MODULE_DIR)
+        links = self.lp.get_wf_by_fw_id(fw_0.fw_id).links
+        det_id = self.lp.fireworks.find_one({'name': det_name}, {'fw_id': True})['fw_id']
+        assert links[fw_11.fw_id] == [det_id]
+        assert links[fw_21.fw_id] == [fw_22.fw_id, det_id]
+        assert links[det_id] == [fw_22.fw_id]
+        assert self.lp.get_fw_by_id(fw_11.fw_id).spec[fw_0_tag] == 0
+        assert self.lp.get_fw_by_id(fw_21.fw_id).spec[fw_0_tag] == 0
+        assert self.lp.get_fw_by_id(det_id).spec[fw_11_tag] == 11
+        assert self.lp.get_fw_by_id(fw_22.fw_id).spec[fw_22_tag] == 32
 
     def test_force_lock_removal(self) -> None:
         test1 = ScriptTask.from_str("python -c 'print(\"test1\")'", {"store_stdout": True})


### PR DESCRIPTION
Closes #549

## Summary

The attributes `additions` and `detours` of `FWAction` class allow dynamic extensions of a workflow. A workflow extension has a parameter `fw_ids` that is a list of IDs of all parent nodes for the extension to be linked. Workflow extensions via `additions` and `detours` are restricted to the parent that is the Firework containing the Firetask returning these actions (quite natural) and this parameter contains only this ID.

In some cases, for example to implement true lazy evaluation with FireWorks, it is necessary to be able to specify additional parent nodes if their evaluation becomes necessary. A typical example is to implement non-strict `if` function but there are more. See [this issue](https://gitlab.kit.edu/kit/virtmat-tools/vre-language/-/issues/449) for more details.

Major changes:

- Add a new attribute to `FWAction` class named `append_wfs`. This action is a list of dictionaries in contrast to `additions` and `detours` that are lists of Workflow objects. The dictionary has a structure following approximately the ‎[Workflow.append_wf](https://github.com/materialsproject/fireworks/blob/main/fireworks/core/firework.py#L1005) function:

  ```python
  {'workflow': Workflow, 'parents': [int], 'detour': bool}
  ```

  The `FWAction.__init__`,  `FWAction.to_dict` and `FWAction.from_dict` and methods have been adapted. The detour is applied to the current Firework (that one returning the FWAction). For the parents in the provided list additions are applied.

- Apply the new action in ‎[Workflow.apply_action](https://github.com/materialsproject/fireworks/blob/main/fireworks/core/firework.py#L888) with splitting the cases of detours and simple additions. The option used `pull_spec_mods=True` is different from the applications of detours and additions (one can discuss about this).

- Fix #549. I came accross the bug only when I was developing this feature. The feature cannot be tested without fixing the bug.

- Generalize `Workflow.append_wf` to accept alternatively a list as `detour` parameter. This is because one may want to avoid detours for all parent nodes. It also can happen that children of the parents for the detour are in COMPLETED state which will lead to an error.

- Adapt the docs about FWAction

- Add two tests: one for the bug fix and one for the new feature

- Add an example in the tutorial about writing firetasks showing how to implement a non-strict if function using FireWorks.

### Alternative approaches
The new action can be seen as a generalization of `additions` and `detours`. Nevertheless, modifying / removing them will introduce a breaking change. Therefore, I have left them untouched.

Another approach is to only add a `parents` attribute like the `propagate`. This looks first a simpler change but it has two drawbacks: 1) it should be technically a list of lists (!) of firework IDs that should mach in length either the `detours` or `additions` lists; 2) it is not clear whether it will be attributed to `additions` or `detours` or both. Therefore, I prefer the explicit  and more structured way.

## Todos

None.

## Checklist

- [ ] ~~Google format doc strings added. Check with `ruff`.~~
- [x] Type annotations included. Check with `mypy`.
- [x] Tests added for new features/fixes.
- [ ] ~~If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))~~

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
