### PR TITLE
`FIZZLE` Fireworks whose tasks can't deserialize and move on in the queue

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -15,7 +15,7 @@ import pprint
 from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Iterator, NoReturn, Sequence
+from typing import Any, Iterator, NoReturn, Self, Sequence
 
 from monty.io import reverse_readline, zopen
 from monty.os.path import zpath
@@ -365,7 +365,7 @@ class Firework(FWSerializable):
 
     @classmethod
     @recursive_deserialize
-    def from_dict(cls, m_dict):
+    def from_dict(cls, m_dict: dict[str, Any]) -> Self:
         tasks = m_dict["spec"]["_tasks"]
         launches = [Launch.from_dict(tmp) for tmp in m_dict.get("launches", [])]
         archived_launches = [Launch.from_dict(tmp) for tmp in m_dict.get("archived_launches", [])]
@@ -373,8 +373,8 @@ class Firework(FWSerializable):
         state = m_dict.get("state", "WAITING")
         created_on = m_dict.get("created_on")
         updated_on = m_dict.get("updated_on")
-        name = m_dict.get("name", None)
-        return Firework(
+        name = m_dict.get("name")
+        return cls(
             tasks, m_dict["spec"], name, launches, archived_launches, state, created_on, fw_id, updated_on=updated_on
         )
 

--- a/fireworks/tests/test_deserialization.py
+++ b/fireworks/tests/test_deserialization.py
@@ -1,0 +1,84 @@
+"""Tests for deserialization failures and DB env var override behavior."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from fireworks.core.firework import Firework, Workflow
+from fireworks.core.launchpad import LaunchPad
+from fireworks.core.rocket_launcher import launch_rocket
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+TESTDB_NAME = "fireworks_unittest"
+
+
+@pytest.fixture(autouse=True)
+def lpad() -> Generator[LaunchPad, None, None]:
+    """Create a clean test database, yield LaunchPad, then drop the database."""
+    try:
+        lp = LaunchPad(name=TESTDB_NAME, strm_lvl="ERROR")
+        lp.reset(password="1970-01-01", require_password=False)
+    except Exception:
+        pytest.skip("MongoDB is not running in localhost:27017! Skipping tests.")
+
+    yield lp
+
+    lp.connection.drop_database(TESTDB_NAME)
+
+
+class FakeBadTask:
+    """Minimal task-like stub whose serialization points to a non-existent class/module."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a bogus `_fw_name` that will fail deserialization."""
+        return {"_fw_name": "totally.invalid.module::Nope"}
+
+
+def test_fizzle_on_deserialization_failure(lpad: LaunchPad, tmp_path) -> None:
+    """A FW whose task cannot be deserialized is marked FIZZLED and skipped."""
+    # Create a Firework whose task serializes to a bogus _fw_name so recursive_deserialize fails
+    fw = Firework(tasks=[FakeBadTask()], name="bad-deser-fw")
+    wf = Workflow.from_firework(fw)
+    lpad.add_wf(wf)
+
+    # Run a rocket; it should attempt checkout, fail to deserialize, mark FIZZLED, and continue without raising
+    # Use a temporary working directory
+    os.chdir(tmp_path)
+    ran = launch_rocket(lpad)
+    # no runnable jobs after fizzling this FW
+    assert ran is False
+
+    fw_dict = lpad.get_fw_dict_by_id(1)
+    assert fw_dict["state"] == "FIZZLED"
+    # ensure exception details were recorded for debugging
+    assert "_exception_details" in fw_dict["spec"]
+
+
+def test_queue_skips_bad_and_runs_next(lpad: LaunchPad, tmp_path) -> None:
+    """If the top-priority FW fails to deserialize, it should be marked as FIZZLED and the queue should move on to the
+    next FW.
+    """
+    # Bad FW with higher priority
+    bad_fw = Firework(tasks=[FakeBadTask()], name="bad-first", spec={"_priority": 100})
+    # Good FW with no tasks (completes immediately) and lower priority
+    good_fw = Firework(tasks=[], name="good-second", spec={"_priority": 1})
+
+    lpad.add_wf(Workflow.from_firework(bad_fw))
+    lpad.add_wf(Workflow.from_firework(good_fw))
+
+    os.chdir(tmp_path)
+    ran = launch_rocket(lpad)
+    # First run fizzles the bad FW and doesn't run anything
+    assert ran is False
+    # Second run should pick up and complete the good FW
+    ran = launch_rocket(lpad)
+
+    bad = lpad.get_fw_dict_by_id(1)
+    good = lpad.get_fw_dict_by_id(2)
+    assert bad["state"] == "FIZZLED"
+    assert good["state"] == "RESERVED"


### PR DESCRIPTION
prev would try to checkout failing FW endlessly, stalling the queue

- change `LaunchPad._get_a_fw_to_run` class to handle deserialization failures more robustly, marking fireworks as FIZZLED when deserialization fails
- add tests for deserialization failures in `test_deserialization.py` confirming un-deserializable fireworks are FIZZLED and the queue continues

this issue was first spotted and the behavior change proposed by @mkhorton 