### PR TITLE
Align FilePad Instance Variables with LaunchPad

### DIFF
--- a/fireworks/utilities/filepad.py
+++ b/fireworks/utilities/filepad.py
@@ -11,7 +11,12 @@ from monty.json import MSONable
 from monty.serialization import loadfn
 from pymongo import DESCENDING
 
-from fireworks.fw_config import LAUNCHPAD_LOC, MONGO_SOCKET_TIMEOUT_MS, STREAM_LOGLEVEL, MongoClient
+from fireworks.fw_config import (
+    LAUNCHPAD_LOC,
+    MONGO_SOCKET_TIMEOUT_MS,
+    STREAM_LOGLEVEL,
+    MongoClient,
+)
 from fireworks.utilities.fw_utilities import get_fw_logger
 
 __author__ = "Kiran Mathew"
@@ -40,7 +45,7 @@ class FilePad(MSONable):
         Args:
             host (str): hostname
             port (int): port number
-            database (str): database name
+            name (str): database name
             username (str)
             password (str).
             authsource (str): authSource parameter for MongoDB authentication; defaults to "name" (i.e., db name) if
@@ -70,7 +75,9 @@ class FilePad(MSONable):
         if uri_mode:
             self.connection = MongoClient(host, **self.mongoclient_kwargs)
             if self.name is None:
-                raise ValueError("Must specify a database name when using a MongoDB URI string.")
+                raise ValueError(
+                    "Must specify a database name when using a MongoDB URI string."
+                )
             self.db = self.connection[self.name]
         else:
             if "socketTimeoutMS" not in self.mongoclient_kwargs:
@@ -99,7 +106,9 @@ class FilePad(MSONable):
         # logging
         self.logdir = logdir
         self.strm_lvl = strm_lvl or STREAM_LOGLEVEL
-        self.logger = get_fw_logger("filepad", l_dir=self.logdir, stream_level=self.strm_lvl)
+        self.logger = get_fw_logger(
+            "filepad", l_dir=self.logdir, stream_level=self.strm_lvl
+        )
 
         # build indexes
         self.build_indexes()


### PR DESCRIPTION
## Summary

Major changes:

- fix 1: Edited `FilePad` URI Parsing to align with logic in `LaunchPad`
- fix 2: For user experience, changed `FilePad.database` -> `FilePad.name` to keep naming conventions between the two consistent.

## Todos

If this is work in progress, what else needs to be done?

There could be better test coverage for this in the case that MongoDB decides to change their connection strings again in the future.

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`. (N/A)
- [x] Tests added for new features/fixes. (See TODO)
- [x] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172)) (N/A)

