### PR TITLE
Support max_loops in multishot mode

### DIFF
--- a/fireworks/features/multi_launcher.py
+++ b/fireworks/features/multi_launcher.py
@@ -43,7 +43,7 @@ def ping_multilaunch(port, stop_event) -> None:
 
 
 def rapidfire_process(
-    fworker, nlaunches, sleep, loglvl, port, node_list, sub_nproc, timeout, running_ids_dict, local_redirect
+    fworker, nlaunches, sleep, loglvl, port, node_list, sub_nproc, timeout, running_ids_dict, local_redirect, max_loops : int
 ) -> None:
     """Initializes shared data with multiprocessing parameters and starts a rapidfire.
 
@@ -58,6 +58,9 @@ def rapidfire_process(
         sub_nproc (int): number of processors of the sub job
         timeout (int): # of seconds after which to stop the rapidfire process
         local_redirect (bool): redirect standard input and output to local file
+        max_loops (int) : After `max_loops` attempts to search for
+            new fireworks to run, a single rapidfire process will terminate.
+            -1 indicates that the process will not stop searching for new jobs to run.
     """
     # Register LaunchPad before connecting to the DataServer (client-side)
     DataServer._register_launchpad()
@@ -79,7 +82,7 @@ def rapidfire_process(
         fworker=fworker,
         m_dir=None,
         nlaunches=nlaunches,
-        max_loops=-1,
+        max_loops=max_loops,
         sleep_time=sleep,
         strm_lvl=loglvl,
         timeout=timeout,
@@ -115,7 +118,7 @@ def rapidfire_process(
                 fworker=fworker,
                 m_dir=None,
                 nlaunches=nlaunches,
-                max_loops=-1,
+                max_loops=max_loops,
                 sleep_time=sleep,
                 strm_lvl=loglvl,
                 timeout=timeout,
@@ -137,6 +140,7 @@ def start_rockets(
     timeout=None,
     running_ids_dict=None,
     local_redirect=False,
+    max_loops : int = -1
 ):
     """Create each sub job and start a rocket launch in each one.
 
@@ -151,13 +155,16 @@ def start_rockets(
         timeout (int): # of seconds after which to stop the rapidfire process
         running_ids_dict (dict): Shared dict between process to record IDs
         local_redirect (bool): redirect standard input and output to local file
+        max_loops (int) : After `max_loops` attempts to search for
+            new fireworks to run, a single rapidfire process will terminate.
+            -1 indicates that the process will not stop searching for new jobs to run.
     Returns:
         ([multiprocessing.Process]) all the created processes
     """
     processes = [
         Process(
             target=rapidfire_process,
-            args=(fworker, nlaunches, sleep, loglvl, port, nl, sub_nproc, timeout, running_ids_dict, local_redirect),
+            args=(fworker, nlaunches, sleep, loglvl, port, nl, sub_nproc, timeout, running_ids_dict, local_redirect, max_loops),
         )
         for nl, sub_nproc in zip(node_lists, sub_nproc_list)
     ]
@@ -205,6 +212,7 @@ def launch_multiprocess(
     timeout=None,
     exclude_current_node=False,
     local_redirect=False,
+    max_loops : int = -1,
 ) -> None:
     """Launch the jobs in the job packing mode.
 
@@ -220,6 +228,9 @@ def launch_multiprocess(
         timeout (int): # of seconds after which to stop the rapidfire process
         exclude_current_node: Don't use the script launching node as a compute node
         local_redirect (bool): redirect standard input and output to local file
+        max_loops (int, default = -1): After `max_loops` attempts to search for
+            new fireworks to run, a single rapidfire process will terminate.
+            -1 indicates that the process will not stop searching for new jobs to run.
     """
     # parse node file contents
     if exclude_current_node:
@@ -251,6 +262,7 @@ def launch_multiprocess(
         timeout=timeout,
         running_ids_dict=running_ids_dict,
         local_redirect=local_redirect,
+        max_loops=max_loops,
     )
     FWData().Running_IDs = running_ids_dict
 

--- a/fireworks/scripts/mlaunch_run.py
+++ b/fireworks/scripts/mlaunch_run.py
@@ -62,6 +62,12 @@ def mlaunch(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--exclude_current_node", help="Don't use the script launching node as compute node", action="store_true"
     )
+    parser.add_argument(
+        "--max_loops",
+        help="after this many sleep loops, quit even in infinite nlaunches mode (default -1 is infinite loops)",
+        default=-1,
+        type=int,
+    )
 
     try:
         import argcomplete
@@ -106,6 +112,7 @@ def mlaunch(argv: Sequence[str] | None = None) -> int:
         args.ppn,
         timeout=args.timeout,
         exclude_current_node=args.exclude_current_node,
+        max_loops = args.max_loops,
     )
 
     return 0

--- a/fireworks/scripts/rlaunch_run.py
+++ b/fireworks/scripts/rlaunch_run.py
@@ -96,6 +96,12 @@ def rlaunch(argv: Sequence[str] | None = None) -> int:
     multi_parser.add_argument(
         "--local_redirect", help="Redirect stdout and stderr to the launch directory", action="store_true"
     )
+    multi_parser.add_argument(
+        "--max_loops",
+        help="after this many sleep loops, quit even in infinite nlaunches mode (default -1 is infinite loops)",
+        default=-1,
+        type=int,
+    )
 
     parser.add_argument("-l", "--launchpad_file", help="path to launchpad file")
     parser.add_argument("-w", "--fworker_file", help="path to fworker file")
@@ -176,6 +182,7 @@ def rlaunch(argv: Sequence[str] | None = None) -> int:
             timeout=args.timeout,
             exclude_current_node=args.exclude_current_node,
             local_redirect=args.local_redirect,
+            max_loops = args.max_loops,
         )
     else:
         launch_rocket(launchpad, fworker, args.fw_id, args.loglvl, pdb_on_exception=args.pdb)


### PR DESCRIPTION
Ports over the `max_loops` (a rapidfire firework will stop running after checking for jobs `max_loops` times and finding none in the READY state) feature from `rlaunch rapidfire` to `rlaunch multi`. Have noticed in testing job packing jobs that this was not supported and has a ***high*** potential to unintentionally waste compute

Have already tested that this works in practice but have not added CI tests