### PR TITLE
Fix `Launch.runtime_secs` `TypeError` with mixed tz-aware/naive datetimes

### DIFF
--- a/fireworks/core/firework.py
+++ b/fireworks/core/firework.py
@@ -665,9 +665,12 @@ class Launch(FWSerializable):
         states = states if isinstance(states, (list, tuple)) else [states]
         for data in self.state_history:
             if data["state"] in states:
-                if use_update_time:
-                    return data["updated_on"]
-                return data["created_on"]
+                time_val = data["updated_on"] if use_update_time else data["created_on"]
+                # Normalize timezone-naive datetimes to UTC-aware to avoid
+                # TypeError when subtracting mixed naive/aware datetimes
+                if time_val is not None and time_val.tzinfo is None:
+                    time_val = time_val.replace(tzinfo=datetime.timezone.utc)
+                return time_val
         return None
 
 


### PR DESCRIPTION
Normalize timezone-naive datetimes to UTC-aware in `Launch._get_time()` to prevent
`TypeError` when subtracting mixed naive/aware datetimes from MongoDB.

```py
Traceback (most recent call last):
  File "/Users/matt/git/periodic-mono/.venv/bin/lpad", line 10, in <module>
    sys.exit(lpad())
             ^^^^^^
  File "/Users/matt/git/periodic-mono/.venv/lib/python3.12/site-packages/fireworks/scripts/lpad_run.py", line 1578, in lpad
    args.func(args)
  File "/Users/matt/git/periodic-mono/.venv/lib/python3.12/site-packages/fireworks/scripts/lpad_run.py", line 503, in detect_lostruns
    fl, ff, fi = lp.detect_lostruns(
                 ^^^^^^^^^^^^^^^^^^^
  File "/Users/matt/git/periodic-mono/.venv/lib/python3.12/site-packages/fireworks/core/launchpad.py", line 1401, in detect_lostruns
    self.mark_fizzled(lid)
  File "/Users/matt/git/periodic-mono/.venv/lib/python3.12/site-packages/fireworks/core/launchpad.py", line 1290, in mark_fizzled
    self.complete_launch(launch_id, state="FIZZLED")
  File "/Users/matt/git/periodic-mono/.venv/lib/python3.12/site-packages/fireworks/core/launchpad.py", line 1572, in complete_launch
    self.launches.find_one_and_replace({"launch_id": m_launch.launch_id}, m_launch.to_db_dict(), upsert=True)
                                                                          ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matt/git/periodic-mono/.venv/lib/python3.12/site-packages/fireworks/utilities/fw_serializers.py", line 153, in _decorator
    m_dict = func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matt/git/periodic-mono/.venv/lib/python3.12/site-packages/fireworks/core/firework.py", line 610, in to_db_dict
    m_d["runtime_secs"] = self.runtime_secs
                          ^^^^^^^^^^^^^^^^^
  File "/Users/matt/git/periodic-mono/.venv/lib/python3.12/site-packages/fireworks/core/firework.py", line 576, in runtime_secs
    return (end - start).total_seconds()
            ~~~~^~~~~~~
TypeError: can't subtract offset-naive and offset-aware datetimes
```