### PR TITLE
Update datetime filter to handle timezone info

### DIFF
--- a/fireworks/flask_site/app.py
+++ b/fireworks/flask_site/app.py
@@ -78,8 +78,10 @@ def _addq_WF(q):
 @app.template_filter("datetime")
 def datetime(value):
     import datetime as dt
-
-    date = dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f%z")
+    try:
+        date = dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f%z")
+    except ValueError: #backwards comptability
+        date = dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
     return date.strftime("%m/%d/%Y")
 
 


### PR DESCRIPTION
### Pull Request Description

**Problem:**  
This pull request fixes a `ValueError` encountered while parsing datetime strings in the Flask app. The error occurred because the datetime format did not account for timezone information (`+00:00`).

**Fix:**  
Added the `%z` format specifier in the `datetime.strptime` method to handle the timezone offset correctly.

**Changes:**  
Updated the code in `app.py` from:
```python
date = dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
```
to:
```python
date = dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f%z")
```

also added backwards compatibility with try/except.