### PR TITLE
[BUG] Fix redirecting traceback from stderr to a file

### DIFF
--- a/fireworks/core/rocket.py
+++ b/fireworks/core/rocket.py
@@ -15,7 +15,7 @@ import pdb
 import shutil
 import traceback
 from threading import Event, Thread, current_thread
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, IO
 
 from monty.io import zopen
 from monty.os.path import zpath
@@ -116,11 +116,12 @@ class Rocket:
         self.fworker = fworker
         self.fw_id = fw_id
 
-    def run(self, pdb_on_exception: bool = False) -> bool:
+    def run(self, pdb_on_exception: bool = False, err_file: IO = None) -> bool:
         """Run the rocket (check out a job from the database and execute it).
 
         Args:
             pdb_on_exception (bool): whether to invoke the debugger on a caught exception. Default to False.
+            err_file (typing.IO): file to which stderr is redirected; None for no redirect
 
         Returns:
             bool: True if the rocket ran successfully, False is if it failed or no job in the DB was ready to run.
@@ -259,7 +260,7 @@ class Rocket:
                 try:
                     m_action = t.run_task(my_spec)
                 except BaseException as e:
-                    traceback.print_exc()
+                    traceback.print_exc(file=err_file)
                     tb = traceback.format_exc()
                     stop_backgrounds(ping_stop, btask_stops)
                     do_ping(lp, launch_id)  # one last ping, esp if there is a monitor

--- a/fireworks/core/rocket_launcher.py
+++ b/fireworks/core/rocket_launcher.py
@@ -32,7 +32,8 @@ def get_fworker(fworker):
     return my_fwkr
 
 
-def launch_rocket(launchpad, fworker=None, fw_id=None, strm_lvl=STREAM_LOGLEVEL, pdb_on_exception=False):
+def launch_rocket(launchpad, fworker=None, fw_id=None, strm_lvl=STREAM_LOGLEVEL,
+                  pdb_on_exception=False, err_file=None):
     """Run a single rocket in the current directory.
 
     Args:
@@ -41,6 +42,7 @@ def launch_rocket(launchpad, fworker=None, fw_id=None, strm_lvl=STREAM_LOGLEVEL,
         fw_id (int): if set, a particular Firework to run
         strm_lvl (str): level at which to output logs to stdout
         pdb_on_exception (bool): if True, Python will start the debugger on a firework exception
+        err_file (file object): file to which stderr is redirected; None for no redirect
 
     Returns:
         bool
@@ -51,7 +53,7 @@ def launch_rocket(launchpad, fworker=None, fw_id=None, strm_lvl=STREAM_LOGLEVEL,
 
     log_multi(l_logger, "Launching Rocket")
     rocket = Rocket(launchpad, fworker, fw_id)
-    rocket_ran = rocket.run(pdb_on_exception=pdb_on_exception)
+    rocket_ran = rocket.run(pdb_on_exception=pdb_on_exception, err_file=err_file)
     log_multi(l_logger, "Rocket finished")
     return rocket_ran
 
@@ -80,7 +82,7 @@ def rapidfire(
         sleep_time (int): secs to sleep between rapidfire loop iterations
         strm_lvl (str): level at which to output logs to stdout
         timeout (int): of seconds after which to stop the rapidfire process
-        local_redirect (bool): redirect standard input and output to local file
+        local_redirect (bool): redirect standard output and standard error to local files
         pdb_on_exception (bool): if True, python will start the debugger on a firework exception
     """
     sleep_time = sleep_time or RAPIDFIRE_SLEEP_SECS
@@ -104,8 +106,10 @@ def rapidfire(
             launcher_dir = create_datestamp_dir(curdir, l_logger, prefix="launcher_")
             os.chdir(launcher_dir)
             if local_redirect:
-                with redirect_local():
-                    rocket_ran = launch_rocket(launchpad, fworker, strm_lvl=strm_lvl, pdb_on_exception=pdb_on_exception)
+                with redirect_local() as err_file:
+                    rocket_ran = launch_rocket(launchpad, fworker, strm_lvl=strm_lvl,
+                                               pdb_on_exception=pdb_on_exception,
+                                               err_file=err_file[1])
             else:
                 rocket_ran = launch_rocket(launchpad, fworker, strm_lvl=strm_lvl, pdb_on_exception=pdb_on_exception)
 

--- a/fireworks/utilities/fw_utilities.py
+++ b/fireworks/utilities/fw_utilities.py
@@ -261,7 +261,9 @@ def explicit_serialize(o):
 
 @contextlib.contextmanager
 def redirect_local(out_file: str = "FW_job.out", err_file: str = "FW_job.error"):
-    """Temporarily redirect stdout or stderr to fws.error and fws.out."""
+    """Temporarily redirect stdout and stderr to files with names
+    out_file and err_file, respectively.
+    """
     try:
         old_err = os.dup(sys.stderr.fileno())
         old_out = os.dup(sys.stdout.fileno())
@@ -271,7 +273,7 @@ def redirect_local(out_file: str = "FW_job.out", err_file: str = "FW_job.error")
 
         os.dup2(new_err.fileno(), sys.stderr.fileno())
         os.dup2(new_out.fileno(), sys.stdout.fileno())
-        yield
+        yield new_out, new_err
 
     finally:
         os.dup2(old_err, sys.stderr.fileno())


### PR DESCRIPTION
Closes #562 

## Summary

Major changes:

- fix 1: Return the file handles from context manager
- fix 2: Pass the stderr file handle as argument so that the traceback function is called with it

## Todos

## Checklist

- [x] Google format doc strings added. Check with `ruff`.
- [x] Type annotations included. Check with `mypy`.
- [x] ~~Tests added for new features/fixes.~~
- [x] ~~If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))~~

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
