### PR TITLE
Bugfix in queue launcher

### DIFF
--- a/fireworks/queue/queue_launcher.py
+++ b/fireworks/queue/queue_launcher.py
@@ -232,7 +232,7 @@ def rapidfire(
             if not block_dir.startswith("block_"):
                 raise ValueError(f"Invalid name {block_dir}, block dirs must start with 'block_")
             block_dir = os.path.abspath(os.path.join(launch_dir, block_dir))
-            os.mkdir(block_dir, exist_ok=True)
+            os.makedirs(block_dir, exist_ok=True)
         elif prev_blocks and not ALWAYS_CREATE_NEW_BLOCK:
             block_dir = os.path.abspath(os.path.join(launch_dir, prev_blocks[0]))
             l_logger.info(f"Found previous block, using {block_dir}")


### PR DESCRIPTION
Small bug if the `block_dir` is specified explicitly, `exist_ok` is passed to `os.mkdir` which is only a valid kwarg for `os.makedirs`