### PR TITLE
Fixing FilePad.update_file()

### DIFF
--- a/docs/_sources/filepad_tutorial.rst.txt
+++ b/docs/_sources/filepad_tutorial.rst.txt
@@ -3,7 +3,7 @@ Using FilePad for storing and retrieving files
 ===============================================
 
 
-FilePad utility provides the api to add and delete arbitrary files of arbitrary sizes to MongoDB(filepad).
+FilePad utility provides the api to add, update and delete arbitrary files of arbitrary sizes to MongoDB(filepad).
 The is achieved by inserting the entire file contents to GridFS and storing the id returned by the
 GridFS insertion, the user provided identifier and the metadata in a document in the filepad. In the following
 documentation, ``file contents`` refers to the file contents stored in GridFS and ``document`` refers to the
@@ -59,6 +59,21 @@ Retrieve all the file contents and the associated documents by a general mongo q
 
 where ``<query>`` is monogo query dict and the returned values ``all_files`` is a list of ``(file_contents, doc)``
 tuples that match the query.
+
+
+Updating files
+=================
+
+To update the file contents associated with an existing identifier::
+
+    old_file_id, new_file_id = fp.update_file(<identifier>, <path>, compress=True/False)
+
+where ``<path>`` is the path to the new file. The old GridFS entry is deleted and the filepad
+document is updated with the new file ID. The old and new file IDs are returned.
+
+To update by the file ID instead::
+
+    old_file_id, new_file_id = fp.update_file_by_id(<file_id>, <path>, compress=True/False)
 
 
 Deleting files

--- a/docs_rst/filepad_tutorial.rst
+++ b/docs_rst/filepad_tutorial.rst
@@ -3,7 +3,7 @@ Using FilePad for storing and retrieving files
 ===============================================
 
 
-FilePad utility provides the api to add and delete arbitrary files of arbitrary sizes to MongoDB(filepad).
+FilePad utility provides the api to add, update and delete arbitrary files of arbitrary sizes to MongoDB(filepad).
 The is achieved by inserting the entire file contents to GridFS and storing the id returned by the
 GridFS insertion, the user provided identifier and the metadata in a document in the filepad. In the following
 documentation, ``file contents`` refers to the file contents stored in GridFS and ``document`` refers to the
@@ -59,6 +59,21 @@ Retrieve all the file contents and the associated documents by a general mongo q
 
 where ``<query>`` is monogo query dict and the returned values ``all_files`` is a list of ``(file_contents, doc)``
 tuples that match the query.
+
+
+Updating files
+=================
+
+To update the file contents associated with an existing identifier::
+
+    old_file_id, new_file_id = fp.update_file(<identifier>, <path>, compress=True/False)
+
+where ``<path>`` is the path to the new file. The old GridFS entry is deleted and the filepad
+document is updated with the new file ID. The old and new file IDs are returned.
+
+To update by the file ID instead::
+
+    old_file_id, new_file_id = fp.update_file_by_id(<file_id>, <path>, compress=True/False)
 
 
 Deleting files

--- a/fireworks/utilities/filepad.py
+++ b/fireworks/utilities/filepad.py
@@ -250,7 +250,8 @@ class FilePad(MSONable):
         return self._update_file_contents(doc, path, compress)
 
     def delete_file_by_id(self, gfs_id) -> None:
-        """
+        """Delete the file from GridFS and remove the associated document from filepad by gfs_id.
+
         Args:
             gfs_id (str): the file id.
         """
@@ -322,7 +323,8 @@ class FilePad(MSONable):
         return None, None
 
     def _update_file_contents(self, doc, path, compress):
-        """
+        """Replace file contents in GridFS and update the filepad document with the new gfs_id.
+
         Args:
             doc (dict): From the filepad collection.
             path (str): Path to the new file whose contents will replace the existing one.

--- a/fireworks/utilities/filepad.py
+++ b/fireworks/utilities/filepad.py
@@ -254,7 +254,7 @@ class FilePad(MSONable):
         Args:
             gfs_id (str): the file id.
         """
-        self.gridfs.delete(gfs_id)
+        self.gridfs.delete(ObjectId(gfs_id))
         self.filepad.delete_one({"gfs_id": gfs_id})
 
     def delete_file_by_query(self, query) -> None:
@@ -301,7 +301,7 @@ class FilePad(MSONable):
         if compress:
             if self.text_mode:
                 contents = contents.encode()
-            contents = zlib.compress(contents, compress)
+            contents = zlib.compress(contents)
         # insert to gridfs
         return str(self.gridfs.put(contents))
 
@@ -334,9 +334,12 @@ class FilePad(MSONable):
         if doc is None:
             return None, None
         old_gfs_id = doc["gfs_id"]
-        self.gridfs.delete(old_gfs_id)
         read_mode = "r" if self.text_mode else "rb"
-        gfs_id = self._insert_to_gridfs(open(path, read_mode).read(), compress)  # noqa: SIM115
+        with open(path, read_mode) as f:
+            contents = f.read()
+        gfs_id = self._insert_to_gridfs(contents, compress)
+        self.gridfs.delete(ObjectId(old_gfs_id))
+        self.filepad.update_one({"gfs_id": old_gfs_id}, {"$set": {"gfs_id": gfs_id, "compressed": compress}})
         doc["gfs_id"] = gfs_id
         doc["compressed"] = compress
         return old_gfs_id, gfs_id
@@ -372,7 +375,7 @@ class FilePad(MSONable):
         return cls(
             host=creds.get("host", "localhost"),
             port=int(creds.get("port", 27017)),
-            database=creds.get("name", "fireworks"),
+            name=creds.get("name", "fireworks"),
             username=user,
             password=password,
             authsource=authsource,

--- a/fireworks/utilities/tests/test_filepad.py
+++ b/fireworks/utilities/tests/test_filepad.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 
+from bson.objectid import ObjectId
+
 from fireworks.utilities.filepad import FilePad
 
 module_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)))
@@ -47,13 +49,25 @@ class FilePadTest(unittest.TestCase):
         old_id, new_id = self.fp.update_file("test_update_file", self.chgcar_file)
         assert old_id == gfs_id
         assert new_id != gfs_id
-        assert not self.fp.gridfs.exists(old_id)
+        assert not self.fp.gridfs.exists(ObjectId(old_id))
+        # verify round-trip: updated file should be retrievable and match original
+        contents, doc = self.fp.get_file("test_update_file")
+        assert doc is not None
+        assert doc["gfs_id"] == new_id
+        with open(self.chgcar_file, "rb") as f:
+            assert contents == f.read()
 
     def test_update_file_by_id(self) -> None:
         gfs_id, _ = self.fp.add_file(self.chgcar_file, identifier="some identifier")
         old, new = self.fp.update_file_by_id(gfs_id, self.chgcar_file)
         assert old == gfs_id
         assert new != gfs_id
+        # verify round-trip: updated file should be retrievable and match original
+        contents, doc = self.fp.get_file_by_id(new)
+        assert doc is not None
+        assert doc["gfs_id"] == new
+        with open(self.chgcar_file, "rb") as f:
+            assert contents == f.read()
 
     def tearDown(self) -> None:
         self.fp.reset()


### PR DESCRIPTION
*Note: This bug fix was created with help of coding agents. Would greatly appreciate any feedback & happy to make further changes.*

## Summary

`FilePad.update_file()` and `FilePad.update_file_by_id()` are broken on main, causing the following problems:

- updates are silently lost
- GridFS storage leaks

This PR includes fixes and documentation updates to correct bugs in the file update feature of FilePad.

## Issue list

| # | Bug | Impact |
|---|-----|--------|
| 1 | `_update_file_contents()` never calls `update_one()` to persist the new `gfs_id` to MongoDB | File updates are silently lost — `get_file()` always returns old content |
| 2 | `from_db_file()` passes `database=` to `__init__()`, but the parameter is named `name` | Instant `TypeError` — `from_db_file()` is unusable |
| 3 | `_update_file_contents()` deletes old GridFS entry before writing the new one | If the new file write fails, the old data is permanently lost |
| 4 | `gridfs.delete()` called with string `gfs_id` instead of `ObjectId` | Silent no-op — GridFS entries are never cleaned up, causing storage leaks |
| 5 | `zlib.compress(contents, compress)` passes boolean `True` as compression level | Compresses at level 1 (weakest) instead of default level 6 — storage inefficiency |
| 6 | `open(path, read_mode).read()` in `_update_file_contents` never closes the file handle | File handle leak on every update |

## Fix list

**`fireworks/utilities/filepad.py`** (lines 257, 304, 334–342, 375):

- **Line 257** (`delete_file_by_id`): Wrap `gfs_id` with `ObjectId()` for proper GridFS deletion.
- **Line 304** (`_insert_to_gridfs`): Remove boolean `compress` argument from `zlib.compress()` call, using the default level 6.
- **Lines 334–342** (`_update_file_contents`): Three fixes applied together:
  - Use `with open()` context manager to prevent file handle leak.
  - Reorder: insert new GridFS entry first, then delete old one (prevents data loss on failure).
  - Add missing `self.filepad.update_one()` call to persist the new `gfs_id` and `compressed` flag to MongoDB.
- **Line 375** (`from_db_file`): Rename `database=` keyword argument to `name=` to match `__init__` signature.

**`fireworks/utilities/tests/test_filepad.py`**:

- Import `ObjectId` for proper GridFS existence checks.
- `test_update_file`: Add round-trip assertion — after update, verify `get_file()` returns updated content and `gfs_id` matches.
- `test_update_file_by_id`: Add round-trip assertion — after update, verify `get_file_by_id()` returns correct content and metadata.

**This fix also contains docstring and package doc changes relevant to FilePad's file update functionality.**